### PR TITLE
feat!: add env files argument

### DIFF
--- a/packages/executor/src/block.ts
+++ b/packages/executor/src/block.ts
@@ -23,7 +23,8 @@ async function runFunction(
 export async function runBlock(
   mainframe: Mainframe,
   payload: ExecutorPayload,
-  sessionDir: string
+  sessionDir: string,
+  contextEnv: { [name: string]: any }
 ): Promise<void> {
   const { session_id, job_id, executor, dir, outputs } = payload;
   const jobInfo = { session_id, job_id };
@@ -39,6 +40,7 @@ export async function runBlock(
       store: valStore,
       storeKey: "store",
       sessionDir,
+      contextEnv,
     });
   } catch (err) {
     logger.error(`create context error`, err);

--- a/packages/executor/src/context.ts
+++ b/packages/executor/src/context.ts
@@ -24,6 +24,7 @@ export async function createContext({
   store,
   storeKey,
   sessionDir,
+  contextEnv,
 }: {
   mainframe: Mainframe;
   jobInfo: JobInfo;
@@ -31,6 +32,7 @@ export async function createContext({
   store: { [index: string]: any };
   storeKey: string;
   sessionDir: string;
+  contextEnv: { [name: string]: any };
 }) {
   const { session_id, job_id } = jobInfo;
 
@@ -85,5 +87,6 @@ export async function createContext({
     store,
     storeKey,
     sessionDir,
+    contextEnv,
   });
 }

--- a/packages/executor/src/executor.ts
+++ b/packages/executor/src/executor.ts
@@ -19,7 +19,7 @@ import {
 } from "./service/topic";
 import { setupSessionLog, logger } from "./logger";
 import { EventEmitter } from "node:events";
-import { isServicePayload } from "./utils";
+import { ExecutorArgs, isServicePayload } from "./utils";
 
 export const valStore: { [index: string]: any } = {};
 
@@ -37,13 +37,8 @@ export async function runExecutor({
   suffix,
   sessionDir,
   package: packagePath,
-}: {
-  address?: string;
-  sessionId: string;
-  suffix?: string;
-  sessionDir: string;
-  package?: string;
-}): Promise<() => void> {
+  envFiles,
+}: ExecutorArgs): Promise<() => void> {
   setupSessionLog({ sessionId, suffix });
 
   logger.info(

--- a/packages/executor/src/file.ts
+++ b/packages/executor/src/file.ts
@@ -1,6 +1,20 @@
 import { writeFile, stat, mkdir, unlink, rmdir } from "fs/promises";
 import { dirname, join } from "node:path";
 import { logger } from "./logger";
+import { readFile } from "node:fs/promises";
+
+export async function loadEnvFile(file: string): Promise<any> {
+  if (file.endsWith(".json")) {
+    const content = await readFile(file, "utf-8");
+    try {
+      return JSON.parse(content);
+    } catch (error) {
+      return {};
+    }
+  }
+  // TODO: add warning logger
+  return {};
+}
 
 async function isDirectory(path: string): Promise<boolean> {
   try {

--- a/packages/executor/src/service/service.ts
+++ b/packages/executor/src/service/service.ts
@@ -148,6 +148,7 @@ class ServiceRuntime implements ServiceContext {
       store: varStore,
       storeKey: "store",
       sessionDir: this.#sessionDir,
+      contextEnv: {}, // TODO: support contextEnv
     });
 
     const originalDone = context.done;

--- a/packages/executor/src/utils.ts
+++ b/packages/executor/src/utils.ts
@@ -7,12 +7,13 @@ import { importFile } from "@hyrious/esbuild-dev";
 import type { ServiceExecutePayload } from "@oomol/oocana-types";
 import { pathToFileURL } from "node:url";
 
-interface ExecutorArgs {
+export interface ExecutorArgs {
   readonly sessionId: string;
   readonly sessionDir: string;
   readonly address?: string;
   readonly suffix?: string;
   readonly package?: string;
+  readonly envFiles?: string[];
 }
 
 export function getExecutorArgs(): ExecutorArgs {
@@ -20,6 +21,7 @@ export function getExecutorArgs(): ExecutorArgs {
     alias: {
       sessionId: "session-id",
       sessionDir: "session-dir",
+      envFiles: "env-files",
     },
   });
 
@@ -39,6 +41,7 @@ interface ServiceArgs {
   readonly sessionId?: string;
   readonly serviceHash: string;
   readonly sessionDir: string;
+  readonly envFiles?: string[]; // TODO: support envFiles
 }
 
 export function getServiceArgs(): ServiceArgs {
@@ -47,6 +50,7 @@ export function getServiceArgs(): ServiceArgs {
       sessionId: "session-id",
       serviceHash: "service-hash",
       sessionDir: "session-dir",
+      envFiles: "env-files",
     },
   });
 

--- a/packages/executor/test/argv.test.ts
+++ b/packages/executor/test/argv.test.ts
@@ -1,7 +1,27 @@
 import { it, expect } from "vitest";
-import { getServiceArgs } from "../src/utils";
+import { getExecutorArgs, getServiceArgs } from "../src/utils";
 
-it("should return getArgv", () => {
+it("executor getArgv", () => {
+  process.argv = [
+    "node",
+    "executor.js",
+    "--session-id",
+    "123",
+    "--session-dir",
+    "/tmp/123",
+    "--env-files",
+    "1.json",
+    "--env-files",
+    "2.json",
+  ];
+  const argv = getExecutorArgs();
+  console.log(argv);
+  expect(argv.sessionId).toBe("123");
+  expect(argv.sessionDir).toBe("/tmp/123");
+  expect(argv.envFiles).toEqual(["1.json", "2.json"]);
+});
+
+it("service getArgv", () => {
   process.argv = [
     "node",
     "executor.js",

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -73,12 +73,11 @@ export class ContextImpl implements Context {
     this.#store = store;
     this.sessionDir = sessionDir;
 
+    const OOMOL_LLM = contextEnv["OOMOL_LLM"] || {};
     this.OOMOL_LLM_ENV = Object.freeze({
-      baseUrl: process.env.OOMOL_LLM_BASE_URL || "",
-      apiKey: process.env.OOMOL_LLM_API_KEY || "",
-      models: process.env.OOMOL_LLM_MODELS
-        ? process.env.OOMOL_LLM_MODELS.split(",")
-        : [],
+      baseUrl: OOMOL_LLM["base_url"] || "",
+      apiKey: OOMOL_LLM["api_key"] || "",
+      models: Array.isArray(OOMOL_LLM["models"]) ? OOMOL_LLM["models"] : [],
     });
 
     this.hostInfo = Object.freeze({

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -49,6 +49,7 @@ export class ContextImpl implements Context {
     store = {},
     storeKey = "store",
     sessionDir,
+    contextEnv,
   }: {
     blockInfo: BlockInfo;
     mainframe: Mainframe;
@@ -57,6 +58,7 @@ export class ContextImpl implements Context {
     store: { [index: string]: any };
     storeKey: string;
     sessionDir: string;
+    contextEnv: { [name: string]: any };
   }) {
     const { session_id, job_id, block_path, stacks } = blockInfo;
     this.mainframe = mainframe;

--- a/packages/oocana/src/oocana.ts
+++ b/packages/oocana/src/oocana.ts
@@ -42,6 +42,8 @@ export interface RunFlowConfig {
   /** Environment variables passed to all executors. All variable names will be converted to uppercase; then if the variable name does not start with OOMOL_, the OOMOL_ prefix will be added automatically. */
   oomolEnvs?: Record<string, string>;
   envs?: Record<string, string>;
+  /** only json file will parsed, other file will be ignored */
+  envFiles?: string[];
 }
 
 export const DEFAULT_PORT = 47688;
@@ -95,6 +97,7 @@ export class Oocana implements IDisposable, OocanaInterface {
     remote,
     oomolEnvs,
     envs,
+    envFiles,
   }: RunFlowConfig): Promise<Cli> {
     if (!this.#address) {
       throw new Error("Cannot run flow without connecting to a broker");
@@ -140,6 +143,17 @@ export class Oocana implements IDisposable, OocanaInterface {
           throw new Error(`Invalid extra bind path: ${path}`);
         }
         args.push("--extra-bind-paths", path);
+      }
+    }
+
+    if (envFiles) {
+      for (const file of envFiles) {
+        if (!file.endsWith(".json")) {
+          throw new Error(
+            `Only JSON files are supported for env files: ${file}`
+          );
+        }
+        args.push("--env-files", file);
       }
     }
 


### PR DESCRIPTION
1. support load env from env files.
2. change LLM_ENV logic which is **breaking change**

## refactor


OOMOL_LLM need a json file, struct like this:

```json
"OOMOL_LLM": {
   "base_url": "string",
   "api_key": "string",
   "models": ["string"]
}
```

This pull request need these work to be done:

- [ ] OOMOL Studio give env files to replace `process.env`. which is **breaking change**.
- [ ] oocana-rust implement `env-files`.
- [ ] oocana-python implement this feature too.