### PR TITLE
chore: add concurrency test case

### DIFF
--- a/flow-examples/package.json
+++ b/flow-examples/package.json
@@ -2,9 +2,10 @@
   "name": "@oomol/oocana-test",
   "private": true,
   "scripts": {
-    "test": "pnpm run query && pnpm run flow && pnpm run cache && pnpm run subflow && pnpm run slot",
+    "test": "pnpm run query && pnpm run concurrency && pnpm run flow && pnpm run cache && pnpm run subflow && pnpm run slot",
     "cache": "vitest run test/cache.test.ts --bail 1",
     "query": "vitest run test/query.test.ts --bail 1",
+    "concurrency": "vitest run test/concurrency.test.ts --bail 1",
     "flow": "vitest run test/flow.test.ts --bail 1",
     "subflow": "vitest run test/subflow.test.ts --bail 1",
     "slot": "vitest run test/slot.test.ts --bail 1",

--- a/flow-examples/test/concurrency.test.ts
+++ b/flow-examples/test/concurrency.test.ts
@@ -1,0 +1,50 @@
+import { it, expect, describe } from "vitest";
+import { runFlow } from "./run";
+
+describe("concurrency test one", () => {
+  it("run pkg flow", async () => {
+    const { code, events } = await runFlow("pkg");
+    expect(code).toBe(0);
+    expect(
+      events.filter(e => e.event === "BlockStarted").length,
+      `start ${events
+        .filter(e => e.event === "BlockStarted")
+        .map(e => JSON.stringify(e.data.stacks))}`
+    ).toBe(4);
+
+    const events_list = events.map(e => e.event);
+    expect(events_list).toContain("SessionFinished");
+  });
+});
+
+describe("concurrency test two", () => {
+  it("run sub flow", async () => {
+    const { code, events } = await runFlow("sub");
+
+    const startedJobs = events
+      .filter(e => e.event === "BlockStarted")
+      .map(e => e.data.job_id);
+
+    const finishedJobs = events
+      .filter(e => e.event === "BlockFinished")
+      .map(e => e.data.job_id);
+
+    expect(
+      startedJobs.length,
+      `started jobs count: ${startedJobs.length} not eq finished jobs count: ${finishedJobs.length}`
+    ).eq(finishedJobs.length);
+    expect(
+      startedJobs.length,
+      `started job evens ${JSON.stringify(startedJobs)}`
+    ).eq(3);
+
+    const e = events.filter(
+      e =>
+        e.event === "BlockFinished" &&
+        e.data.stacks.filter(e => e.node_id === "+javascript#2").length == 1
+    );
+    expect(e.length).toBe(1);
+
+    expect(code).toBe(0);
+  });
+});

--- a/flow-examples/test/subflow.test.ts
+++ b/flow-examples/test/subflow.test.ts
@@ -1,6 +1,5 @@
-import { it, expect } from "vitest";
+import { it, expect, describe } from "vitest";
 import { runFlow } from "./run";
-import { describe } from "node:test";
 
 describe("subflow test", () => {
   it("run sub flow", async () => {


### PR DESCRIPTION
During previous testing, issues arose due to concurrent execution of the tests, resulting in frequent errors. 
This pull request add a couple of unit tests using 'describe' to conduct thorough checks.