### PR TITLE
feat: add flow node store feature

### DIFF
--- a/.github/workflows/layer.yml
+++ b/.github/workflows/layer.yml
@@ -82,7 +82,12 @@ jobs:
           sleep 5
           cd flow-examples
           pnpm run test
-      # - name: Setup tmate session # only enable when debugging
-      #   uses: mxschmitt/action-tmate@v3
-      #   timeout-minutes: 10
-      #   if: failure()
+      - name: upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: oocana-logs
+          path: |
+            ~/.oocana/sessions/
+            /tmp/ovmlayer.log
+          retention-days: 1
+        if: failure()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,3 +53,12 @@ jobs:
           sleep 5
           pnpm run -F oocana-test nonlayer
           pnpm run test
+      - name: upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: oocana-logs
+          path: |
+            ~/.oocana/sessions/
+            /tmp/ovmlayer.log
+          retention-days: 1
+        if: failure()

--- a/flow-examples/flows/one-subflow-twice-subflow-node/flow.oo.yaml
+++ b/flow-examples/flows/one-subflow-twice-subflow-node/flow.oo.yaml
@@ -1,0 +1,75 @@
+nodes:
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#1.js
+    node_id: +javascript#1
+    inputs_from:
+      - handle: input
+        value: javascript
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#1.js
+    node_id: +javascript#11
+    inputs_from:
+      - handle: input
+        value: javascript
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#1.js
+    node_id: +javascript#2
+    inputs_from:
+      - handle: input
+        from_node:
+          - node_id: node-1
+            output_handle: output
+  - subflow: self::basic
+    node_id: node-1
+    inputs_from:
+      - handle: input
+        from_node:
+          - node_id: +javascript#1
+            output_handle: output
+          - node_id: +javascript#11
+            output_handle: output

--- a/flow-examples/flows/one-subflow-twice-subflow-node/scriptlets/+javascript#1.js
+++ b/flow-examples/flows/one-subflow-twice-subflow-node/scriptlets/+javascript#1.js
@@ -1,0 +1,19 @@
+//#region generated meta
+/**
+ * @typedef {{
+ *   input: string;
+ * }} Inputs;
+ * @typedef {{
+ *   output: string;
+ * }} Outputs;
+ */
+//#endregion
+
+/**
+ * @param {Inputs} params
+ * @param {import("@oomol/types/oocana").Context<Inputs, Outputs>} context
+ * @returns {Promise<Outputs>}
+ */
+export default async function (params, context) {
+  return { output: params.input };
+}

--- a/flow-examples/flows/sub-twice/flow.oo.yaml
+++ b/flow-examples/flows/sub-twice/flow.oo.yaml
@@ -1,0 +1,75 @@
+nodes:
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#1.js
+    node_id: +javascript#1
+    inputs_from:
+      - handle: input
+        value: javascript
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#1.js
+    node_id: +javascript#11
+    inputs_from:
+      - handle: input
+        value: javascript
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#1.js
+    node_id: +javascript#2
+    inputs_from:
+      - handle: input
+        from_node:
+          - node_id: node-1
+            output_handle: output
+  - subflow: self::basic
+    node_id: node-1
+    inputs_from:
+      - handle: input
+        from_node:
+          - node_id: +javascript#1
+            output_handle: output
+          - node_id: +javascript#11
+            output_handle: output

--- a/flow-examples/flows/sub-twice/scriptlets/+javascript#1.js
+++ b/flow-examples/flows/sub-twice/scriptlets/+javascript#1.js
@@ -1,0 +1,19 @@
+//#region generated meta
+/**
+ * @typedef {{
+ *   input: string;
+ * }} Inputs;
+ * @typedef {{
+ *   output: string;
+ * }} Outputs;
+ */
+//#endregion
+
+/**
+ * @param {Inputs} params
+ * @param {import("@oomol/types/oocana").Context<Inputs, Outputs>} context
+ * @returns {Promise<Outputs>}
+ */
+export default async function (params, context) {
+  return { output: params.input };
+}

--- a/flow-examples/subflows/basic/scriptlets/+javascript#1.js
+++ b/flow-examples/subflows/basic/scriptlets/+javascript#1.js
@@ -15,5 +15,14 @@
  * @returns {Promise<Outputs>}
  */
 export default async function (params, context) {
+  const v1 = context.flowNodeStore["v1"];
+  const v2 = context.flowNodeStore["v2"];
+
+  if (v1 && v2) {
+    throw new Error("v1 and v2 already exist");
+  } else {
+    context.flowNodeStore["v1"] = "v1";
+    context.flowNodeStore["v2"] = "v2";
+  }
   return { output: params.input };
 }

--- a/flow-examples/subflows/node-twice/scriptlets/+javascript#1.js
+++ b/flow-examples/subflows/node-twice/scriptlets/+javascript#1.js
@@ -1,0 +1,19 @@
+//#region generated meta
+/**
+ * @typedef {{
+ *   input: string;
+ * }} Inputs;
+ * @typedef {{
+ *   output: string;
+ * }} Outputs;
+ */
+//#endregion
+
+/**
+ * @param {Inputs} params
+ * @param {import("@oomol/types/oocana").Context<Inputs, Outputs>} context
+ * @returns {Promise<Outputs>}
+ */
+export default async function (params, context) {
+  return { output: params.input };
+}

--- a/flow-examples/subflows/node-twice/scriptlets/+javascript#2.js
+++ b/flow-examples/subflows/node-twice/scriptlets/+javascript#2.js
@@ -1,0 +1,33 @@
+//#region generated meta
+/**
+ * @typedef {{
+ *   input: string;
+ * }} Inputs;
+ * @typedef {{
+ *   output: string;
+ * }} Outputs;
+ */
+//#endregion
+
+/**
+ * @param {Inputs} params
+ * @param {import("@oomol/types/oocana").Context<Inputs, Outputs>} context
+ * @returns {Promise<Outputs>}
+ */
+export default async function (params, context) {
+  const v1 = context.flowNodeStore["v1"];
+  const v2 = context.flowNodeStore["v2"];
+
+  if (v1 && v2) {
+    if (v1 !== "v1") {
+      throw new Error("v1 not equal to v1");
+    }
+    if (v2 !== "v2") {
+      throw new Error("v2 not equal to v2");
+    }
+  } else {
+    context.flowNodeStore["v1"] = "v1";
+    context.flowNodeStore["v2"] = "v2";
+  }
+  return { output: params.input };
+}

--- a/flow-examples/subflows/node-twice/subflow.oo.yml
+++ b/flow-examples/subflows/node-twice/subflow.oo.yml
@@ -1,0 +1,79 @@
+nodes:
+  - task:
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#1.js
+    node_id: subflow-basic#1
+    inputs_from:
+      - handle: input
+        from_flow:
+          - input_handle: input
+  - task:
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#1.js
+    node_id: subflow-basic#11
+    inputs_from:
+      - handle: input
+        from_flow:
+          - input_handle: input
+  - task:
+      inputs_def:
+        - handle: input
+          description: Input
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: output
+          description: Output
+          json_schema:
+            type: string
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+javascript#2.js
+    node_id: subflow-basic#2
+    inputs_from:
+      - handle: input
+        from_node:
+          - node_id: subflow-basic#1
+            output_handle: output
+          - node_id: subflow-basic#11
+            output_handle: output
+inputs_def:
+  - handle: input
+    description: Input
+    json_schema:
+      type: string
+outputs_def:
+  - handle: output
+    description: Output
+    json_schema:
+      type: string
+outputs_from:
+  - handle: output
+    from_node:
+      - node_id: subflow-basic#1
+        output_handle: output

--- a/flow-examples/test/subflow.test.ts
+++ b/flow-examples/test/subflow.test.ts
@@ -31,4 +31,14 @@ describe("subflow test", () => {
 
     expect(code).toBe(0);
   });
+
+  it("run sub flow", async () => {
+    const { code, events } = await runFlow("one-subflow-twice-subflow-node");
+    expect(code).toBe(0);
+  });
+
+  it("run sub flow", async () => {
+    const { code, events } = await runFlow("sub-twice");
+    expect(code).toBe(0);
+  });
 });

--- a/packages/executor/src/block.ts
+++ b/packages/executor/src/block.ts
@@ -27,7 +27,8 @@ export async function runBlock(
   sessionDir: string,
   tmpDir: string,
   packageName: string,
-  pkgDir: string
+  pkgDir: string,
+  flowStore: Map<string, { [node: string]: any }>
 ): Promise<void> {
   const { session_id, job_id, executor, dir, outputs } = payload;
   const jobInfo = { session_id, job_id };
@@ -46,6 +47,7 @@ export async function runBlock(
       tmpDir,
       packageName,
       pkgDir,
+      flowStore,
     });
   } catch (err) {
     logger.error(`create context error`, err);

--- a/packages/executor/src/context.ts
+++ b/packages/executor/src/context.ts
@@ -27,6 +27,7 @@ export async function createContext({
   tmpDir,
   packageName,
   pkgDir,
+  flowStore,
 }: {
   mainframe: Mainframe;
   jobInfo: JobInfo;
@@ -37,6 +38,7 @@ export async function createContext({
   tmpDir: string;
   packageName: string;
   pkgDir: string;
+  flowStore: Map<string, { [node: string]: any }>;
 }) {
   const { session_id, job_id } = jobInfo;
 
@@ -78,6 +80,16 @@ export async function createContext({
   const block_path = blockReadyResponse.block_path;
   const stacks = Object.freeze(blockReadyResponse.stacks);
 
+  let combine_node_id = "node";
+  if (stacks.length > 0) {
+    stacks.forEach(stack => {
+      combine_node_id += `${stack.flow_job_id}_${stack.node_id}`;
+    });
+  }
+
+  const flowNodeStore = flowStore.get(combine_node_id) || {};
+  flowNodeStore.set(combine_node_id, flowNodeStore);
+
   return new ContextImpl({
     blockInfo: {
       session_id,
@@ -94,5 +106,6 @@ export async function createContext({
     tmpDir,
     packageName,
     pkgDir,
+    flowNodeStore,
   });
 }

--- a/packages/executor/src/context.ts
+++ b/packages/executor/src/context.ts
@@ -87,8 +87,11 @@ export async function createContext({
     });
   }
 
-  const flowNodeStore = flowStore.get(combine_node_id) || {};
-  flowNodeStore.set(combine_node_id, flowNodeStore);
+  let flowNodeStore = flowStore.get(combine_node_id);
+  if (!flowNodeStore) {
+    flowNodeStore = new Map();
+    flowStore.set(combine_node_id, flowNodeStore);
+  }
 
   return new ContextImpl({
     blockInfo: {

--- a/packages/executor/src/executor.ts
+++ b/packages/executor/src/executor.ts
@@ -32,6 +32,7 @@ import path from "node:path";
 export const valStore: { [index: string]: any } = {};
 
 const jobSet = new Set<string>();
+const nodeStoreMap = new Map<string, { [index: string]: any }>();
 
 type ServiceStatus = "running" | "launching";
 
@@ -79,14 +80,22 @@ export async function runExecutor({
         return;
       }
 
-      // https://github.com/oomol/oocana-rust/issues/310 临时解决方案
+      // oocana-rust 会重复发送 job_id
       if (jobSet.has(payload.job_id)) {
         logger.warn(`job ${payload.job_id} is running, ignore`);
         return;
       }
       jobSet.add(payload.job_id);
 
-      runBlock(mainframe, payload, sessionDir, tmpDir, packageName, pkgDir);
+      runBlock(
+        mainframe,
+        payload,
+        sessionDir,
+        tmpDir,
+        packageName,
+        pkgDir,
+        nodeStoreMap
+      );
     }
   );
 

--- a/packages/executor/src/service/service.ts
+++ b/packages/executor/src/service/service.ts
@@ -155,7 +155,7 @@ class ServiceRuntime implements ServiceContext {
       tmpDir: this.#sessionDir, // TODO: use tmpDir and need consider global service
       packageName: this.#serviceHash,
       pkgDir: this.#pkgDir,
-      flowNodeStore: {}, // TODO: implement flowNodeStore
+      flowStore: {} as any, // TODO: implement flowNodeStore
     });
 
     const originalDone = context.done;

--- a/packages/executor/src/service/service.ts
+++ b/packages/executor/src/service/service.ts
@@ -155,6 +155,7 @@ class ServiceRuntime implements ServiceContext {
       tmpDir: this.#sessionDir, // TODO: use tmpDir and need consider global service
       packageName: this.#serviceHash,
       pkgDir: this.#pkgDir,
+      flowNodeStore: {}, // TODO: implement flowNodeStore
     });
 
     const originalDone = context.done;

--- a/packages/executor/src/service/service.ts
+++ b/packages/executor/src/service/service.ts
@@ -155,7 +155,7 @@ class ServiceRuntime implements ServiceContext {
       tmpDir: this.#sessionDir, // TODO: use tmpDir and need consider global service
       packageName: this.#serviceHash,
       pkgDir: this.#pkgDir,
-      flowStore: {} as any, // TODO: implement flowNodeStore
+      flowStore: new Map(), // TODO: implement flowNodeStore
     });
 
     const originalDone = context.done;

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -27,7 +27,7 @@ export class ContextImpl implements Context {
   readonly jobId: string;
   readonly block_path?: string;
   readonly stacks: readonly BlockJobStackLevel[];
-  #store: { [index: string]: any };
+  #variableStore: { [index: string]: any };
   static readonly keepAlive = Symbol("keepAlive");
   keepAlive = ContextImpl.keepAlive;
   private isDone = false;
@@ -77,7 +77,7 @@ export class ContextImpl implements Context {
     this.stacks = stacks;
     this.inputs = inputs;
     this.node_id = stacks[stacks.length - 1]?.node_id;
-    this.#store = store;
+    this.#variableStore = store;
     this.sessionDir = sessionDir;
     this.tmpDir = tmpDir;
     this.packageName = packageName;
@@ -249,7 +249,7 @@ export class ContextImpl implements Context {
     if (isValHandle(outputsDef, handle) && !this.isBasicType(output)) {
       const objectRef = this.createObjectRef(handle);
       const ref = outputRefKey(objectRef);
-      this.#store[ref] = value;
+      this.#variableStore[ref] = value;
       value = {
         __OOMOL_TYPE__: "oomol/var",
         value: objectRef,

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -30,6 +30,7 @@ export class ContextImpl implements Context {
   #variableStore: { [index: string]: any };
   static readonly keepAlive = Symbol("keepAlive");
   keepAlive = ContextImpl.keepAlive;
+  readonly flowNodeStore: { [index: string]: any };
   private isDone = false;
   private mainframe: Mainframe;
   private outputsDef: HandlesDef;
@@ -55,6 +56,7 @@ export class ContextImpl implements Context {
     tmpDir,
     packageName,
     pkgDir,
+    flowNodeStore,
   }: {
     blockInfo: BlockInfo;
     mainframe: Mainframe;
@@ -66,6 +68,7 @@ export class ContextImpl implements Context {
     tmpDir: string;
     packageName: string;
     pkgDir: string;
+    flowNodeStore: { [index: string]: any };
   }) {
     const { session_id, job_id, block_path, stacks } = blockInfo;
     this.mainframe = mainframe;
@@ -77,6 +80,7 @@ export class ContextImpl implements Context {
     this.stacks = stacks;
     this.inputs = inputs;
     this.node_id = stacks[stacks.length - 1]?.node_id;
+    this.flowNodeStore = flowNodeStore;
     this.#variableStore = store;
     this.sessionDir = sessionDir;
     this.tmpDir = tmpDir;

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -78,6 +78,7 @@ export interface Context<
    *   } else {
    *     value += 1;
    *   }
+   *   context.flowNodeStore["key"] = value
    *   console.log("value:", value);
    * }
    *

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -67,6 +67,27 @@ export interface Context<
   readonly stacks: readonly BlockJobStackLevel[];
   readonly inputs: TInputs;
 
+  /**
+   * persist data across job running for same node it. For subflow, each subflow job will possess different flow store.
+   * usage example:
+   * ```ts
+   * function main(inputs, context) {
+   *   let value = context.flowNodeStore["key"];
+   *   if (value === undefined) {
+   *     value = 0;
+   *   } else {
+   *     value += 1;
+   *   }
+   *   console.log("value:", value);
+   * }
+   *
+   * the first time node run, value will be 0
+   * the second time node run, value will be 1
+   * these jobs are different. but they are in the same flow, so they share the same flowNodeStore.
+   * ```
+   */
+  readonly flowNodeStore: { [index: string]: any };
+
   readonly output: {
     <THandle extends Extract<keyof TOutputs, string>>(
       handle: THandle,


### PR DESCRIPTION

persist data across job running for same node it. For subflow, each subflow job will possess different flow store.
usage example:
```ts
function main(inputs, context) {
  let value = context.flowNodeStore["key"];
  if (value === undefined) {
    value = 0;
  } else {
    value += 1;
  }
  context.flowNodeStore["key"] = value
  console.log("value:", value);
}
the first time node run, value will be 0
the second time node run, value will be 1
these jobs are different. but they are in the same flow, so they share the same flowNodeStore.
```

for flow, you can use this api or initiate variable outside function which is already supported.