### PR TITLE
fix: add workaround for wrap module issue 90

### DIFF
--- a/packages/executor/src/utils.ts
+++ b/packages/executor/src/utils.ts
@@ -202,6 +202,18 @@ export function findFunction(m: any, name: string | undefined): any {
     return m.main;
   }
 
+  // workaround for issue #90
+  const wrapModule = m.default || m;
+  if (wrapModule && typeof wrapModule === "object") {
+    if (name && typeof wrapModule[name] === "function") {
+      return wrapModule[name];
+    } else if (typeof wrapModule.default === "function") {
+      return wrapModule.default;
+    } else if (typeof wrapModule.main === "function") {
+      return wrapModule.main;
+    }
+  }
+
   if (name && m[name]) {
     throw new Error(`${name} is not a function but typeof ${typeof m[name]}`);
   } else if (m.default) {


### PR DESCRIPTION
fix #90 .
It appears that the module occasionally wraps itself in default, as illustrated below:

```javascript
[Module: null prototype] {
  default: [Module: null prototype] { main: [AsyncFunction: main] }
}
```

The underlying reason remains unclear, thus this pull request serves merely as a temporary solution for this behavior.
