### PR TITLE
feat: improve finish message and remove done flag in output message

### DIFF
--- a/flow-examples/flows/basic/flow.oo.yaml
+++ b/flow-examples/flows/basic/flow.oo.yaml
@@ -1,0 +1,44 @@
+nodes:
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: in
+          value: input value
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: a
+        - handle: b
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+typescript#1.ts
+    title: "TypeScript #1"
+    node_id: +typescript#1
+    inputs_from:
+      - handle: in
+        value: aaaa
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: a
+          value: input value
+      outputs_def:
+        - handle: out
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+typescript#2.ts
+    title: "TypeScript #2"
+    node_id: +typescript#2
+    inputs_from:
+      - handle: a
+        from_node:
+          - node_id: +typescript#1
+            output_handle: a
+      - handle: b
+        from_node:
+          - node_id: +typescript#1
+            output_handle: b

--- a/flow-examples/flows/basic/scriptlets/+typescript#1.ts
+++ b/flow-examples/flows/basic/scriptlets/+typescript#1.ts
@@ -1,0 +1,17 @@
+import type { Context } from "@oomol/oocana-types";
+
+type Inputs = {
+  in: unknown;
+};
+type Outputs = {
+  a: string;
+  b: string;
+};
+
+export default async function (
+  _inputs: Inputs,
+  context: Context<Inputs, Outputs>
+): Promise<Outputs> {
+  context.outputs({ a: "a", b: "b" });
+  return { a: "a", b: "b" };
+}

--- a/flow-examples/flows/basic/scriptlets/+typescript#2.ts
+++ b/flow-examples/flows/basic/scriptlets/+typescript#2.ts
@@ -1,0 +1,16 @@
+import type { Context } from "@oomol/types/oocana";
+
+type Inputs = {
+  a: string;
+  b: string;
+};
+type Outputs = {
+  out: string;
+};
+
+export default async function (
+  _inputs: Inputs,
+  _context: Context<Inputs, Outputs>
+): Promise<Outputs> {
+  return { out: "out" };
+}

--- a/flow-examples/flows/bin/flow.oo.yaml
+++ b/flow-examples/flows/bin/flow.oo.yaml
@@ -4,7 +4,6 @@ nodes:
         default_width: 450
       inputs_def:
         - handle: in
-          ignoreNull: true
           value: input value
           description: Input
           json_schema:
@@ -19,7 +18,6 @@ nodes:
         options:
           entry: scriptlets/+typescript#1.ts
     title: "TypeScript #1"
-    icon: ":skill-icons:typescript:"
     node_id: +typescript#1
     inputs_from:
       - handle: in
@@ -43,7 +41,6 @@ nodes:
         options:
           entry: scriptlets/+typescript#2.ts
     title: "TypeScript #2"
-    icon: ":skill-icons:typescript:"
     node_id: +typescript#2
     inputs_from:
       - handle: a

--- a/flow-examples/flows/warning/flow.oo.yaml
+++ b/flow-examples/flows/warning/flow.oo.yaml
@@ -1,0 +1,21 @@
+nodes:
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: in
+          value: input value
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: a
+        - handle: b
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+typescript#1.ts
+    title: "TypeScript #1"
+    node_id: +typescript#1
+    inputs_from:
+      - handle: in
+        value: aaaa

--- a/flow-examples/flows/warning/scriptlets/+typescript#1.ts
+++ b/flow-examples/flows/warning/scriptlets/+typescript#1.ts
@@ -1,0 +1,16 @@
+import type { Context } from "@oomol/oocana-types";
+
+type Inputs = {
+  in: unknown;
+};
+type Outputs = {
+  a: string;
+  b: string;
+};
+
+export default async function (
+  _inputs: Inputs,
+  context: Context<Inputs, Outputs>
+): Promise<Outputs> {
+  return { a: "a", b: "b", c: "c" } as Outputs;
+}

--- a/flow-examples/test/flow.test.ts
+++ b/flow-examples/test/flow.test.ts
@@ -18,6 +18,39 @@ describe(
       console.log("files", files);
     });
 
+    it("run basic flow", async () => {
+      const { code, events } = await runFlow("basic");
+      expect(code).toBe(0);
+      expect(
+        events.filter(e => e.event === "BlockStarted").length,
+        `start ${events
+          .filter(e => e.event === "BlockStarted")
+          .map(e => JSON.stringify(e.data.stacks))}`
+      ).toBe(3);
+
+      expect(
+        events
+          .filter(e => e.event === "BlockOutputMap")
+          .filter(e => e.data.map?.a === "a" && e.data.map?.b === "b").length,
+        `finish ${events
+          .filter(e => e.event === "BlockFinished")
+          .map(e => JSON.stringify(e.data.stacks))}`
+      ).toBe(1);
+
+      expect(
+        events
+          .filter(e => e.event === "BlockFinished")
+          .filter(e => e.data.result?.a === "a" && e.data.result?.b === "b")
+          .length,
+        `finish ${events
+          .filter(e => e.event === "BlockFinished")
+          .map(e => JSON.stringify(e.data.stacks))}`
+      ).toBe(1);
+
+      const events_list = events.map(e => e.event);
+      expect(events_list).toContain("SessionFinished");
+    });
+
     it("run pkg flow", async () => {
       const { code, events } = await runFlow("pkg");
       expect(code).toBe(0);

--- a/flow-examples/test/flow.test.ts
+++ b/flow-examples/test/flow.test.ts
@@ -100,6 +100,18 @@ describe(
       expect(latestBlockOutput).toBe(3);
     });
 
+    it("run warning flow", async () => {
+      const { code, events } = await runFlow("warning");
+      expect(code).toBe(0);
+
+      const latestBlockWarning = events.findLast(
+        e => e.event === "BlockWarning"
+      )?.data?.warning;
+      expect(latestBlockWarning).toBe(
+        "Output handle key: [c] is not defined in Block outputs schema."
+      );
+    });
+
     it("run service flow", async () => {
       const { code, events } = await runFlow("service");
       expect(code).toBe(0);

--- a/flow-examples/test/flow.test.ts
+++ b/flow-examples/test/flow.test.ts
@@ -69,8 +69,9 @@ describe(
       const { code, events } = await runFlow("var");
       expect(code).toBe(0);
 
-      const latestBlockOutput = events.findLast(e => e.event === "BlockOutput")
-        ?.data?.output;
+      const latestBlockOutput = events.findLast(
+        e => e.event === "BlockFinished"
+      )?.data?.result?.out;
       expect(latestBlockOutput).toBe("ok");
     });
 
@@ -128,8 +129,8 @@ describe(
     it("run value flow", async () => {
       const { code, events } = await runFlow("value");
       expect(code).toBe(0);
-      const output = events.findLast(e => e.event === "BlockOutput")?.data
-        ?.output;
+      const output = events.findLast(e => e.event === "BlockFinished")?.data
+        ?.result?.out;
       expect(output).toEqual(null);
     });
 

--- a/packages/executor/src/block.ts
+++ b/packages/executor/src/block.ts
@@ -78,7 +78,7 @@ export async function runBlock(
     }
   } catch (error) {
     logger.error(`get module error`, error);
-    context.done(error);
+    context.finish({ error });
     return;
   }
 
@@ -89,6 +89,6 @@ export async function runBlock(
     logger.info(`run block success job_id: ${job_id}`);
   } catch (error) {
     logger.error(`run block job_id: ${job_id} error`, error);
-    context.done(error);
+    context.finish({ error });
   }
 }

--- a/packages/executor/src/service/service.ts
+++ b/packages/executor/src/service/service.ts
@@ -159,9 +159,9 @@ class ServiceRuntime implements ServiceContext {
     });
 
     const originalDone = context.finish;
-    context.finish = async () => {
+    context.finish = async (...args) => {
       this.#runningBlocks.delete(job_id);
-      await originalDone();
+      await originalDone(...args);
       if (this.#runningBlocks.size === 0) {
         this.startExitTimerIfNeeded();
       }

--- a/packages/executor/src/service/service.ts
+++ b/packages/executor/src/service/service.ts
@@ -158,8 +158,8 @@ class ServiceRuntime implements ServiceContext {
       flowStore: new Map(), // TODO: implement flowNodeStore
     });
 
-    const originalDone = context.done;
-    context.done = async () => {
+    const originalDone = context.finish;
+    context.finish = async () => {
       this.#runningBlocks.delete(job_id);
       await originalDone();
       if (this.#runningBlocks.size === 0) {

--- a/packages/executor/src/utils.ts
+++ b/packages/executor/src/utils.ts
@@ -76,24 +76,17 @@ export async function outputWithReturnObject(
 ) {
   if (result === undefined) {
     context.finish();
-  }
-
-  // done 的权限移交给用户，让用户自主决定 done 的时机。
-  if (result === context.keepAlive) {
-    return;
-  }
-
-  // only accept object
-  if (typeof result !== "object" || result === null) {
+  } else if (result === context.keepAlive) {
+    // pass
+  } else if (typeof result !== "object" || result === null) {
     context.finish({
       error: new Error(
         `return value must be an object, but get ${inspect(result)}`
       ),
     });
-    return;
+  } else {
+    context.finish({ result });
   }
-
-  context.finish({ result });
 }
 
 const caches = new Set<string>();

--- a/packages/executor/src/utils.ts
+++ b/packages/executor/src/utils.ts
@@ -6,6 +6,7 @@ import { logger } from "./logger";
 import { importFile } from "@hyrious/esbuild-dev";
 import type { ServiceExecutePayload } from "@oomol/oocana-types";
 import { pathToFileURL } from "node:url";
+import { inspect } from "node:util";
 
 export interface ExecutorArgs {
   readonly sessionId: string;
@@ -84,7 +85,11 @@ export async function outputWithReturnObject(
 
   // only accept object
   if (typeof result !== "object" || result === null) {
-    context.finish({ error: new Error("return value must be an object") });
+    context.finish({
+      error: new Error(
+        `return value must be an object, but get ${inspect(result)}`
+      ),
+    });
     return;
   }
 
@@ -205,17 +210,11 @@ export function findFunction(m: any, name: string | undefined): any {
     }
   }
 
-  if (name && m[name]) {
-    throw new Error(`${name} is not a function but typeof ${typeof m[name]}`);
-  } else if (m.default) {
-    throw new Error(`default is not a function but typeof ${typeof m.default}`);
-  } else if (m.main) {
-    throw new Error(`main is not a function but typeof ${typeof m.main}`);
-  } else {
-    throw new Error(
-      "Unable to find any callable function in the default or main field. Maybe you should check the entry file is correct"
-    );
-  }
+  throw new Error(
+    `Unable to find any callable function in the default or main field for module: ${inspect(
+      m
+    )}`
+  );
 }
 
 export async function getEntryPath(entry: string, cwd: string = process.cwd()) {

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -124,12 +124,14 @@ export class ContextImpl implements Context {
 
   finish = async (arg?: { result?: any; error?: unknown }) => {
     const { result, error } = arg || {};
-    const errorMessage =
-      error instanceof Error ? `${error.message}\n${error.stack}` : `${error}`;
 
     this.reportProgress.flush();
 
-    if (!!errorMessage) {
+    if (!!error) {
+      const errorMessage =
+        error instanceof Error
+          ? `${error.message}\n${error.stack}`
+          : `${error}`;
       await this.mainframe.sendFinish({
         type: "BlockFinished",
         session_id: this.sessionId,

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -245,11 +245,7 @@ export class ContextImpl implements Context {
       });
     }, 300);
 
-  output = async <THandle extends string>(
-    handle: THandle,
-    output: any,
-    done = false
-  ) => {
+  output = async <THandle extends string>(handle: THandle, output: any) => {
     const outputsDef = this.outputsDef;
     let value = output;
     if (isValHandle(outputsDef, handle) && !this.isBasicType(output)) {
@@ -289,10 +285,6 @@ export class ContextImpl implements Context {
         `Output handle key: [${handle}] is not defined in Block outputs schema.`
       );
 
-      if (done) {
-        this.done();
-      }
-
       return;
     }
 
@@ -302,13 +294,8 @@ export class ContextImpl implements Context {
       job_id: this.jobId,
       handle,
       output: value,
-      done,
     });
 
     this.reportProgress.flush();
-
-    if (done) {
-      this.done();
-    }
   };
 }

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -142,7 +142,7 @@ export class ContextImpl implements Context {
       const wrapResult: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(result)) {
         if (!(key in this.outputsDef)) {
-          this.warning(
+          await this.warning(
             `Output handle key: [${key}] is not defined in Block outputs schema.`
           );
           continue;

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -294,6 +294,30 @@ export class ContextImpl implements Context {
     return value;
   };
 
+  outputs = async (map: Partial<Record<string, any>>) => {
+    const wrapResult: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(map)) {
+      if (!(key in this.outputsDef)) {
+        await this.warning(
+          `Output handle key: [${key}] is not defined in Block outputs schema.`
+        );
+        continue;
+      }
+      try {
+        wrapResult[key] = await this.wrapOutputValue(key, value);
+      } catch (error) {
+        this.error(error);
+      }
+    }
+
+    await this.mainframe.sendOutputs({
+      type: "BlockOutputMap",
+      session_id: this.sessionId,
+      job_id: this.jobId,
+      map: wrapResult,
+    });
+  };
+
   output = async <THandle extends string>(handle: THandle, output: any) => {
     if (!(handle in this.outputsDef)) {
       await this.warning(

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -328,7 +328,7 @@ export class ContextImpl implements Context {
 
     let value;
     try {
-      value = this.wrapOutputValue(handle, output);
+      value = await this.wrapOutputValue(handle, output);
     } catch (error) {
       this.error(error);
       return;

--- a/packages/oocana-sdk/src/mainframe.ts
+++ b/packages/oocana-sdk/src/mainframe.ts
@@ -14,6 +14,7 @@ import type {
   IReporterClientMessage,
   IMainframeExecutorReady,
   IReporterBlockWarning,
+  IMainframeBlockOutputMap,
 } from "@oomol/oocana-types";
 
 export class Mainframe {
@@ -124,6 +125,10 @@ export class Mainframe {
   }
 
   public async sendOutput(message: IMainframeBlockOutput): Promise<void> {
+    await this.send(message);
+  }
+
+  public async sendOutputs(message: IMainframeBlockOutputMap): Promise<void> {
     await this.send(message);
   }
 

--- a/packages/oocana-types/src/block.ts
+++ b/packages/oocana-types/src/block.ts
@@ -38,6 +38,7 @@ export interface IMainframeBlockError extends JobInfo {
 export interface IMainframeBlockFinished extends JobInfo {
   type: "BlockFinished";
   error?: string;
+  result?: Record<string, unknown>;
 }
 
 export type IMainframeServerMessage = IMainframeBlockInputs;

--- a/packages/oocana-types/src/block.ts
+++ b/packages/oocana-types/src/block.ts
@@ -30,6 +30,11 @@ export interface IMainframeBlockOutput<TOutput = any> extends JobInfo {
   output: TOutput;
 }
 
+export interface IMainframeBlockOutputMap<TOutput = any> extends JobInfo {
+  type: "BlockOutputMap";
+  map: Record<string, TOutput>;
+}
+
 export interface IMainframeBlockError extends JobInfo {
   type: "BlockError";
   error: string;
@@ -45,6 +50,7 @@ export type IMainframeServerMessage = IMainframeBlockInputs;
 export type IMainframeClientMessage =
   | IMainframeBlockReady
   | IMainframeBlockOutput
+  | IMainframeBlockOutputMap
   | IMainframeBlockError
   | IMainframeBlockFinished
   | IMainframeExecutorReady;

--- a/packages/oocana-types/src/block.ts
+++ b/packages/oocana-types/src/block.ts
@@ -28,7 +28,6 @@ export interface IMainframeBlockOutput<TOutput = any> extends JobInfo {
   type: "BlockOutput";
   handle: string;
   output: TOutput;
-  done: boolean;
 }
 
 export interface IMainframeBlockError extends JobInfo {

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -96,8 +96,6 @@ export interface Context<
     ): Promise<void>;
 
     /**
-     * @deprecated this method will be removed in the future. please use function without done parameter. if you want to report block done, please use context.done() instead.
-     * Report Block output.
      * @param handle Output handle
      * @param output Output value
      */
@@ -106,6 +104,13 @@ export interface Context<
       output: TOutputs[THandle]
     ): Promise<void>;
   };
+
+  /**
+   * Report block outputs. it can report multiple output at once.
+   * @param map map can be a partial object of TOutputs
+   * @returns
+   */
+  readonly outputs: (map: Partial<TOutputs>) => Promise<void>;
 
   /**
    * reporter block finish. it can contain error or result.

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -109,8 +109,15 @@ export interface Context<
     ): Promise<void>;
   };
 
-  /** Report Block done. */
-  readonly done: (err?: any) => Promise<void>;
+  /**
+   * reporter block finish. it can contain error or result.
+   * if contains error, it will be treated as block failed and ignore result argument
+   * if contains result, it will be treated as success
+   * otherwise, it will be treated as success and no result will be reported.
+   */
+  readonly finish: (
+    arg?: { result?: any; error?: never } | { result?: never; error?: unknown }
+  ) => Promise<void>;
 
   /** Report logs */
   readonly logJSON: (jsonValue: unknown) => Promise<void>;

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -100,12 +100,10 @@ export interface Context<
      * Report Block output.
      * @param handle Output handle
      * @param output Output value
-     * @param done will remove. Report Block done.
      */
     <THandle extends Extract<keyof TOutputs, string>>(
       handle: THandle,
-      output: TOutputs[THandle],
-      done: boolean
+      output: TOutputs[THandle]
     ): Promise<void>;
   };
 

--- a/packages/oocana-types/src/external/reporter.ts
+++ b/packages/oocana-types/src/external/reporter.ts
@@ -79,6 +79,7 @@ export interface BlockStarted extends BlockInfo {
 export interface BlockFinished extends BlockInfo {
   readonly type: "BlockFinished";
   readonly error?: string;
+  readonly result?: Record<string, any>;
   readonly finish_at: number;
 }
 

--- a/packages/oocana-types/src/external/reporter.ts
+++ b/packages/oocana-types/src/external/reporter.ts
@@ -89,6 +89,11 @@ export interface BlockOutput extends BlockInfo {
   readonly output: any;
 }
 
+export interface BlockOutputMap extends BlockInfo {
+  readonly type: "BlockOutputMap";
+  readonly map: Record<string, any>;
+}
+
 export interface BlockLog extends BlockInfo {
   readonly type: "BlockLog";
   readonly log: string;
@@ -137,6 +142,7 @@ export interface JobEventMap {
   BlockStarted: BlockStarted;
   BlockFinished: BlockFinished;
   BlockOutput: BlockOutput;
+  BlockOutputMap: BlockOutputMap;
   BlockLog: BlockLog;
   BlockError: BlockError;
   FlowStarted: FlowStarted;

--- a/packages/oocana-types/src/external/reporter.ts
+++ b/packages/oocana-types/src/external/reporter.ts
@@ -87,7 +87,6 @@ export interface BlockOutput extends BlockInfo {
   readonly type: "BlockOutput";
   readonly handle: string;
   readonly output: any;
-  readonly done: boolean;
 }
 
 export interface BlockLog extends BlockInfo {


### PR DESCRIPTION
- `BlockFinished` message add `result` option field, support return multiple handle at once when block finish.
- `BlockOutput` message remove `done` field
- add `BlockOutputMap` message support output multiple handle at once.