### PR TITLE
chore: move oocana-node action to self repo

### DIFF
--- a/.github/actions/oocana-node/action.yml
+++ b/.github/actions/oocana-node/action.yml
@@ -1,0 +1,52 @@
+name: "setup oocana-node"
+description: "setup oocana-node on ubuntu-latest with optional layer"
+inputs:
+  token:
+    description: "GitHub token"
+    required: true
+    default: ${{ github.token }}
+  create-layer:
+    description: "create layer"
+    required: false
+    default: "false"
+  ref:
+    description: "GitHub ref"
+    required: false
+    default: ""
+  path:
+    description: "GitHub path"
+    required: false
+    default: "."
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: oomol/oocana-node
+        path: ${{ inputs.path }}
+        ref: ${{ inputs.ref }}
+        token: ${{ inputs.token }}
+    - uses: pnpm/action-setup@v4
+      with:
+        package_json_file: ${{ inputs.path }}/package.json
+    - uses: actions/setup-node@v4
+      with:
+        registry-url: https://npm.pkg.github.com/
+        node-version: 22.x
+        cache: pnpm
+        cache-dependency-path: ${{ inputs.path }}/pnpm-lock.yaml
+    - name: install
+      run: pnpm install
+      shell: bash
+      working-directory: ${{ inputs.path }}
+    - name: build
+      run: pnpm build
+      shell: bash
+      working-directory: ${{ inputs.path }}
+    - name: create-layer
+      if: ${{ inputs.create-layer != 'false' }}
+      run: |
+        node ./layer.mjs
+      shell: bash
+      working-directory: ${{ inputs.path }}

--- a/.github/workflows/oocana-node.yml
+++ b/.github/workflows/oocana-node.yml
@@ -1,0 +1,49 @@
+name: "setup oocana-node action"
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/oocana-node.yml"
+      - ".github/actions/oocana-node/**"
+      - "executor.sh"
+      - "install-node.sh"
+      - "layer.mjs"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  action-test:
+    runs-on: ubuntu-latest
+    env:
+      OVMLAYER_LOG: /tmp/ovmlayer.log
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: oomol/oocana-rust/.github/actions/ovmlayer@main
+        with:
+          rootfs: https://github.com/oomol/ovmlayer-rootfs/releases/download/base-rootfs%400.3.0/amd64-rootfs.tar
+          token: ${{ secrets.ACCESS_REPO }}
+      - name: setup oocana-node action without layer
+        uses: ./.github/actions/oocana-node
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.sha }}
+          path: "oocana-node"
+      - name: setup oocana-node action with layer
+        uses: ./.github/actions/oocana-node
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.sha }}
+          create-layer: "true"
+          path: "oocana-node"
+      - name: upload log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ovmlayer-log
+          path: /tmp/ovmlayer.log

--- a/layer.mjs
+++ b/layer.mjs
@@ -1,6 +1,7 @@
 import { exec } from "child_process";
-import { existsSync } from "fs";
-import { readFile, writeFile } from "fs/promises";
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import os from "os";
 
 (async function () {
@@ -23,6 +24,7 @@ import os from "os";
 
   console.log("Layer not found");
   await createExecutor();
+  await mkdir(dirname(layer), { recursive: true });
   writeFile(layer, JSON.stringify({ base_rootfs: ["executor"] }));
 })();
 


### PR DESCRIPTION
move [oocana-rust oocana-node action](https://github.com/oomol/oocana-rust/blob/main/.github/actions/oocana-node/action.yml) to oocana-node self host.