### PR TITLE
chore(test): add value on inputs from instead of using block input def value

### DIFF
--- a/flow-examples/flows/progress/flow.oo.yaml
+++ b/flow-examples/flows/progress/flow.oo.yaml
@@ -1,6 +1,9 @@
 nodes:
   - node_id: a
     task: my-pkg::block-h
+    inputs_from:
+      - handle: count
+        value: 0
   - node_id: b
     task: my-pkg::block-h
     inputs_from:


### PR DESCRIPTION
As design, oocana should not use block's input def value. Oocana should use input from's value and ignore block input def.