### PR TITLE
feat: add run block api

### DIFF
--- a/flow-examples/flows/run-block/flow.oo.yaml
+++ b/flow-examples/flows/run-block/flow.oo.yaml
@@ -1,0 +1,44 @@
+nodes:
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: in
+          value: input value
+          json_schema:
+            type: string
+      outputs_def:
+        - handle: a
+        - handle: b
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+typescript#1.ts
+    title: "TypeScript #1"
+    node_id: +typescript#1
+    inputs_from:
+      - handle: in
+        value: aaaa
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: a
+          value: input value
+      outputs_def:
+        - handle: out
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+typescript#2.ts
+    title: "TypeScript #2"
+    node_id: +typescript#2
+    inputs_from:
+      - handle: a
+        from_node:
+          - node_id: +typescript#1
+            output_handle: a
+      - handle: b
+        from_node:
+          - node_id: +typescript#1
+            output_handle: b

--- a/flow-examples/flows/run-block/scriptlets/+typescript#1.ts
+++ b/flow-examples/flows/run-block/scriptlets/+typescript#1.ts
@@ -14,11 +14,11 @@ export default async function (
 ): Promise<Outputs> {
   context.outputs({ a: "a", b: "b" });
   console.log("Running block with inputs:", _inputs);
-  const events = await context.runBlock("counter", { input: "test" });
-  const p = new Promise(resolve => {
-    events.on("BlockFinished", payload => {
-      resolve(payload);
-    });
+  const res = await context.runBlock("counter", { input: "test" });
+  res.onOutput(data => {
+    console.log("Output from counter block:", data);
   });
+  const result = await res.result;
+  console.log("Result from counter block:", result);
   return { a: "a", b: "b" };
 }

--- a/flow-examples/flows/run-block/scriptlets/+typescript#1.ts
+++ b/flow-examples/flows/run-block/scriptlets/+typescript#1.ts
@@ -1,0 +1,24 @@
+import type { Context } from "@oomol/oocana-types";
+
+type Inputs = {
+  in: unknown;
+};
+type Outputs = {
+  a: string;
+  b: string;
+};
+
+export default async function (
+  _inputs: Inputs,
+  context: Context<Inputs, Outputs>
+): Promise<Outputs> {
+  context.outputs({ a: "a", b: "b" });
+  console.log("Running block with inputs:", _inputs);
+  const events = await context.runBlock("counter", { input: "test" });
+  const p = new Promise(resolve => {
+    events.on("BlockFinished", payload => {
+      resolve(payload);
+    });
+  });
+  return { a: "a", b: "b" };
+}

--- a/flow-examples/flows/run-block/scriptlets/+typescript#1.ts
+++ b/flow-examples/flows/run-block/scriptlets/+typescript#1.ts
@@ -18,7 +18,7 @@ export default async function (
   res.onOutput(data => {
     console.log("Output from counter block:", data);
   });
-  const result = await res.result;
+  const result = await res.finish;
   console.log("Result from counter block:", result);
   return { a: "a", b: "b" };
 }

--- a/flow-examples/flows/run-block/scriptlets/+typescript#1.ts
+++ b/flow-examples/flows/run-block/scriptlets/+typescript#1.ts
@@ -14,11 +14,21 @@ export default async function (
 ): Promise<Outputs> {
   context.outputs({ a: "a", b: "b" });
   console.log("Running block with inputs:", _inputs);
+
+  // Run the "counter" block with some input
   const res = await context.runBlock("counter", { input: "test" });
   res.onOutput(data => {
-    console.log("Output from counter block:", data);
+    const { handle, value } = data;
+    console.log(
+      `Received output from counter block: handle=${handle}, output=${value}`
+    );
   });
-  const result = await res.finish;
-  console.log("Result from counter block:", result);
+  const { result, error } = await res.finish();
+  if (error) {
+    console.error("Error in counter block:", error);
+    throw new Error("Counter block failed with error: " + error);
+  } else {
+    console.log("Result from counter block:", result);
+  }
   return { a: "a", b: "b" };
 }

--- a/flow-examples/flows/run-block/scriptlets/+typescript#2.ts
+++ b/flow-examples/flows/run-block/scriptlets/+typescript#2.ts
@@ -10,7 +10,17 @@ type Outputs = {
 
 export default async function (
   _inputs: Inputs,
-  _context: Context<Inputs, Outputs>
+  context: Context<Inputs, Outputs>
 ): Promise<Outputs> {
+  const res = await context.runBlock("counter11", { input: "test" });
+  const data = await res.finish;
+  console.log("Result from counter block:", data);
+  if (data.error) {
+    console.error("Error in counter block:", data.error);
+  } else {
+    throw new Error(
+      "Expected an error, but got result: " + JSON.stringify(data.result)
+    );
+  }
   return { out: "out" };
 }

--- a/flow-examples/flows/run-block/scriptlets/+typescript#2.ts
+++ b/flow-examples/flows/run-block/scriptlets/+typescript#2.ts
@@ -1,4 +1,4 @@
-import type { Context } from "@oomol/types/oocana";
+import type { Context } from "@oomol/oocana-types";
 
 type Inputs = {
   a: string;

--- a/flow-examples/flows/run-block/scriptlets/+typescript#2.ts
+++ b/flow-examples/flows/run-block/scriptlets/+typescript#2.ts
@@ -13,7 +13,7 @@ export default async function (
   context: Context<Inputs, Outputs>
 ): Promise<Outputs> {
   const res = await context.runBlock("counter11", { input: "test" });
-  const data = await res.finish;
+  const data = await res.finish();
   console.log("Result from counter block:", data);
   if (data.error) {
     console.error("Error in counter block:", data.error);

--- a/flow-examples/flows/run-block/scriptlets/+typescript#2.ts
+++ b/flow-examples/flows/run-block/scriptlets/+typescript#2.ts
@@ -1,0 +1,16 @@
+import type { Context } from "@oomol/types/oocana";
+
+type Inputs = {
+  a: string;
+  b: string;
+};
+type Outputs = {
+  out: string;
+};
+
+export default async function (
+  _inputs: Inputs,
+  _context: Context<Inputs, Outputs>
+): Promise<Outputs> {
+  return { out: "out" };
+}

--- a/flow-examples/package.json
+++ b/flow-examples/package.json
@@ -17,7 +17,7 @@
     "@oomol/oocana-types": "workspace:*"
   },
   "devDependencies": {
-    "remitter": "^0.4.6",
+    "remitter": "^0.5.0",
     "vitest": "^3.1.0"
   }
 }

--- a/flow-examples/test/flow.test.ts
+++ b/flow-examples/test/flow.test.ts
@@ -66,8 +66,8 @@ describe(
         events.filter(e => e.event === "BlockStarted").length,
         `start ${events
           .filter(e => e.event === "BlockStarted")
-          .map(e => JSON.stringify(e.data.stacks))}`
-      ).toBe(3);
+          .map(e => JSON.stringify(e.data))}`
+      ).toBe(4);
 
       expect(
         events

--- a/flow-examples/test/flow.test.ts
+++ b/flow-examples/test/flow.test.ts
@@ -59,6 +59,47 @@ describe(
       expect(sessionFinished[0].data.partial).not.toBeUndefined();
     });
 
+    it("run run-block flow", async () => {
+      const { code, events } = await runFlow("run-block");
+      expect(code).toBe(0);
+      expect(
+        events.filter(e => e.event === "BlockStarted").length,
+        `start ${events
+          .filter(e => e.event === "BlockStarted")
+          .map(e => JSON.stringify(e.data.stacks))}`
+      ).toBe(3);
+
+      expect(
+        events
+          .filter(e => e.event === "BlockOutputs")
+          .filter(e => e.data.outputs?.a === "a" && e.data.outputs?.b === "b")
+          .length,
+        `finish ${events
+          .filter(e => e.event === "BlockFinished")
+          .map(e => JSON.stringify(e.data.stacks))}`
+      ).toBe(1);
+
+      expect(
+        events
+          .filter(e => e.event === "BlockFinished")
+          .filter(e => e.data.result?.a === "a" && e.data.result?.b === "b")
+          .length,
+        `finish ${events
+          .filter(e => e.event === "BlockFinished")
+          .map(e => JSON.stringify(e.data.stacks))}`
+      ).toBe(1);
+
+      const events_list = events.map(e => e.event);
+
+      const sessionStarted = events.filter(e => e.event === "SessionStarted");
+      const sessionFinished = events.filter(e => e.event === "SessionFinished");
+      expect(sessionStarted.length).toBe(1);
+      expect(sessionFinished.length).toBe(1);
+
+      expect(sessionStarted[0].data.partial).not.toBeUndefined();
+      expect(sessionFinished[0].data.partial).not.toBeUndefined();
+    });
+
     it("run pkg flow", async () => {
       const { code, events } = await runFlow("pkg");
       expect(code).toBe(0);

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -31,6 +31,6 @@
     "winston": "^3.13.1",
     "@hyrious/esbuild-dev": "^0.10.10",
     "minimist": "^1.2.7",
-    "remitter": "^0.4.6"
+    "remitter": "^0.5.0"
   }
 }

--- a/packages/oocana-sdk/package.json
+++ b/packages/oocana-sdk/package.json
@@ -33,6 +33,6 @@
     "@types/lodash.throttle": "^4.1.9",
     "@wopjs/event": "^0.1.5",
     "lodash.throttle": "^4.1.1",
-    "remitter": "^0.4.6"
+    "remitter": "^0.5.0"
   }
 }

--- a/packages/oocana-sdk/package.json
+++ b/packages/oocana-sdk/package.json
@@ -29,9 +29,10 @@
     "mqtt": "^5.7.0"
   },
   "devDependencies": {
-    "@wopjs/event": "^0.1.5",
     "@oomol/oocana-types": "workspace:*",
     "@types/lodash.throttle": "^4.1.9",
-    "lodash.throttle": "^4.1.1"
+    "@wopjs/event": "^0.1.5",
+    "lodash.throttle": "^4.1.1",
+    "remitter": "^0.4.6"
   }
 }

--- a/packages/oocana-sdk/package.json
+++ b/packages/oocana-sdk/package.json
@@ -29,8 +29,9 @@
     "mqtt": "^5.7.0"
   },
   "devDependencies": {
-    "lodash.throttle": "^4.1.1",
+    "@wopjs/event": "^0.1.5",
     "@oomol/oocana-types": "workspace:*",
-    "@types/lodash.throttle": "^4.1.9"
+    "@types/lodash.throttle": "^4.1.9",
+    "lodash.throttle": "^4.1.1"
   }
 }

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -204,7 +204,7 @@ export class ContextImpl implements Context {
   };
 
   runBlock = async (blockName: string, inputs: Record<string, any>) => {
-    const block_job_id = `${this.jobId}-${blockName}`;
+    const block_job_id = `${this.jobId}-${blockName}-${Date.now()}`;
     await this.mainframe.sendRun({
       type: "RunBlock",
       session_id: this.sessionId,

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -267,13 +267,14 @@ export class ContextImpl implements Context {
       resolver = resolve;
     });
 
-    const response: RunResponse = {
+    // remitter Symbol issue.
+    const response = {
       events,
       onOutput,
       finish: () => finishP,
-    };
+    } as any;
 
-    response.finish().then(_data => {
+    response.finish().then(() => {
       dispose();
     });
 

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -202,6 +202,17 @@ export class ContextImpl implements Context {
     });
   };
 
+  runBlock = async (blockName: string, inputs: Record<string, any>) => {
+    await this.mainframe.sendRun({
+      type: "RunBlock",
+      session_id: this.sessionId,
+      job_id: this.jobId,
+      stacks: this.stacks,
+      block: blockName,
+      inputs,
+    });
+  };
+
   warning = async (msg: string) => {
     await this.mainframe.sendWarning({
       type: "BlockWarning",

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -248,6 +248,15 @@ export class ContextImpl implements Context {
         resolver({ result: payload.result, error: payload.error });
       }
     };
+    this.mainframe.addSessionCallback(this.sessionId, blockEvent);
+
+    const errorEvent = (payload: any) => {
+      if (payload?.job_id !== block_job_id) {
+        return;
+      }
+      resolver({ error: payload.error });
+    };
+    this.mainframe.addRunBlockCallback(this.sessionId, errorEvent);
 
     const response: RunResponse = {
       events,
@@ -257,6 +266,7 @@ export class ContextImpl implements Context {
         error?: unknown;
       }>(resolve => {
         this.mainframe.removeSessionCallback(this.sessionId, blockEvent);
+        this.mainframe.removeRunBlockCallback(this.sessionId, errorEvent);
         resolver = resolve;
       }),
     };

--- a/packages/oocana-sdk/src/mainframe.ts
+++ b/packages/oocana-sdk/src/mainframe.ts
@@ -15,6 +15,7 @@ import type {
   IMainframeExecutorReady,
   IReporterBlockWarning,
   IMainframeBlockOutputs,
+  IMainframeBlockRunPayload,
 } from "@oomol/oocana-types";
 
 export class Mainframe {
@@ -137,6 +138,10 @@ export class Mainframe {
   }
 
   public async sendError(message: IMainframeBlockError): Promise<void> {
+    await this.send(message);
+  }
+
+  public async sendRun(message: IMainframeBlockRunPayload): Promise<void> {
     await this.send(message);
   }
 

--- a/packages/oocana-sdk/src/mainframe.ts
+++ b/packages/oocana-sdk/src/mainframe.ts
@@ -22,7 +22,7 @@ export class Mainframe {
   private mqtt: MqttClient;
 
   private hashMap: Map<string, OnMessageCallback> = new Map();
-  private reporterCallbacks: Set<any> = new Set();
+  private reporterCallbacks: Set<(payload: IReporterClientMessage) => void> = new Set();
   public connectingPromise: Promise<void>;
 
   public constructor(address: string, clientId?: string) {

--- a/packages/oocana-types/package.json
+++ b/packages/oocana-types/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",
-    "remitter": "^0.4.6",
+    "remitter": "^0.5.0",
     "rollup": "^4.17.2",
     "rollup-plugin-dts": "^6.1.0"
   }

--- a/packages/oocana-types/package.json
+++ b/packages/oocana-types/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",
+    "remitter": "^0.4.6",
     "rollup": "^4.17.2",
     "rollup-plugin-dts": "^6.1.0"
   }

--- a/packages/oocana-types/rollup.config.ts
+++ b/packages/oocana-types/rollup.config.ts
@@ -4,13 +4,13 @@ import type { RollupOptions } from "rollup";
 const config: RollupOptions = {
   input: "./src/index.ts",
   output: [{ file: "dist/index.d.ts", format: "es" }],
-  plugins: [dts()],
+  plugins: [dts({ respectExternal: true })],
 };
 
 const external: RollupOptions = {
   input: "./src/external/index.ts",
   output: [{ file: "dist/oocana.d.ts", format: "es" }],
-  plugins: [dts()],
+  plugins: [dts({ respectExternal: true })],
 };
 
 export default [config, external];

--- a/packages/oocana-types/src/block.ts
+++ b/packages/oocana-types/src/block.ts
@@ -64,6 +64,13 @@ export type IMainframeClientMessage =
   | IMainframeBlockRunPayload
   | IMainframeExecutorReady;
 
+export type BlockActionEvent = {
+  BlockOutput: IMainframeBlockOutput;
+  BlockOutputs: IMainframeBlockOutputs;
+  BlockFinished: IMainframeBlockFinished;
+  BlockError: IMainframeBlockError;
+};
+
 export interface ExecutorPayload extends JobInfo {
   dir: string;
   executor: {

--- a/packages/oocana-types/src/block.ts
+++ b/packages/oocana-types/src/block.ts
@@ -1,4 +1,4 @@
-import { BlockInfo, JobInfo } from "./external/block";
+import { BlockInfo, BlockJobStackLevel, JobInfo } from "./external/block";
 import type { HandlesDef, HandlesDefPatch } from "./schema";
 
 export interface IMainframeBlockInputs<
@@ -12,6 +12,13 @@ export interface IMainframeBlockInputs<
 
 export interface IMainframeBlockReady extends JobInfo {
   type: "BlockReady";
+}
+
+export interface IMainframeBlockRunPayload extends JobInfo {
+  type: "RunBlock";
+  block: string;
+  inputs: Record<string, unknown>;
+  stacks: readonly BlockJobStackLevel[];
 }
 
 export interface IMainframeExecutorReady {
@@ -53,6 +60,7 @@ export type IMainframeClientMessage =
   | IMainframeBlockOutputs
   | IMainframeBlockError
   | IMainframeBlockFinished
+  | IMainframeBlockRunPayload
   | IMainframeExecutorReady;
 
 export interface ExecutorPayload extends JobInfo {

--- a/packages/oocana-types/src/block.ts
+++ b/packages/oocana-types/src/block.ts
@@ -17,6 +17,7 @@ export interface IMainframeBlockReady extends JobInfo {
 export interface IMainframeBlockRunPayload extends JobInfo {
   type: "RunBlock";
   block: string;
+  block_job_id: string;
   inputs: Record<string, unknown>;
   stacks: readonly BlockJobStackLevel[];
 }

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -1,4 +1,4 @@
-import type { Remitter } from "remitter";
+import type { EventReceiver } from "remitter";
 import { HandlesDef } from "../schema";
 import type { BlockJobStackLevel } from "./block";
 import { BlockActionEvent } from "../block";
@@ -71,7 +71,7 @@ export type HostInfo = {
 };
 
 export type RunResponse = {
-  events: Remitter<BlockActionEvent>;
+  events: EventReceiver<BlockActionEvent>;
   onOutput(listener: (data: { handle: string; value: unknown }) => void): void;
   finish(): Promise<{ result?: Record<string, unknown>; error?: unknown }>;
 };

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -77,7 +77,7 @@ export type HostInfo = {
 export type RunResponse = {
   events: EventEmitter;
   onOutput(listener: (data: { handle: string; value: unknown }) => void): void;
-  result: Promise<{ result?: Record<string, unknown>; error?: unknown }>;
+  finish: Promise<{ result?: Record<string, unknown>; error?: unknown }>;
 };
 
 export interface Context<

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -1,11 +1,7 @@
-import type { EventEmitter } from "events";
+import type { Remitter } from "remitter";
 import { HandlesDef } from "../schema";
 import type { BlockJobStackLevel } from "./block";
-import {
-  IMainframeBlockRunPayload,
-  IMainframeClientMessage,
-  IMainframeExecutorReady,
-} from "../block";
+import { BlockActionEvent } from "../block";
 
 export type PreviewType =
   | "image"
@@ -75,7 +71,7 @@ export type HostInfo = {
 };
 
 export type RunResponse = {
-  events: EventEmitter;
+  events: Remitter<BlockActionEvent>;
   onOutput(listener: (data: { handle: string; value: unknown }) => void): void;
   finish(): Promise<{ result?: Record<string, unknown>; error?: unknown }>;
 };

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -123,6 +123,11 @@ export interface Context<
    */
   readonly outputs: (map: Partial<TOutputs>) => Promise<void>;
 
+  readonly runBlock: (
+    blockName: string,
+    inputs: Record<string, any>
+  ) => Promise<void>;
+
   /**
    * reporter block finish. it can contain error or result.
    * if contains error, it will be treated as block failed and ignore result argument

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "events";
+import type { EventEmitter } from "events";
 import { HandlesDef } from "../schema";
 import type { BlockJobStackLevel } from "./block";
 

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -1,6 +1,11 @@
 import type { EventEmitter } from "events";
 import { HandlesDef } from "../schema";
 import type { BlockJobStackLevel } from "./block";
+import {
+  IMainframeBlockRunPayload,
+  IMainframeClientMessage,
+  IMainframeExecutorReady,
+} from "../block";
 
 export type PreviewType =
   | "image"
@@ -69,6 +74,12 @@ export type HostInfo = {
   readonly gpuRenderer: string;
 };
 
+export type RunResponse = {
+  events: EventEmitter;
+  onOutput(listener: (data: { handle: string; value: unknown }) => void): void;
+  result: Promise<{ result?: Record<string, unknown>; error?: unknown }>;
+};
+
 export interface Context<
   TInputs = Record<string, any>,
   TOutputs = Record<string, any>
@@ -127,7 +138,7 @@ export interface Context<
   readonly runBlock: (
     blockName: string,
     inputs: Record<string, any>
-  ) => Promise<EventEmitter>;
+  ) => Promise<RunResponse>;
 
   /**
    * reporter block finish. it can contain error or result.

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -77,7 +77,7 @@ export type HostInfo = {
 export type RunResponse = {
   events: EventEmitter;
   onOutput(listener: (data: { handle: string; value: unknown }) => void): void;
-  finish: Promise<{ result?: Record<string, unknown>; error?: unknown }>;
+  finish(): Promise<{ result?: Record<string, unknown>; error?: unknown }>;
 };
 
 export interface Context<
@@ -138,7 +138,7 @@ export interface Context<
   readonly runBlock: (
     blockName: string,
     inputs: Record<string, any>
-  ) => Promise<RunResponse>;
+  ) => RunResponse;
 
   /**
    * reporter block finish. it can contain error or result.

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -72,7 +72,9 @@ export type HostInfo = {
 
 export type RunResponse = {
   events: EventReceiver<BlockActionEvent>;
-  onOutput(listener: (data: { handle: string; value: unknown }) => void): void;
+  onOutput(
+    listener: (data: { handle: string; value: unknown }) => void
+  ): () => void;
   finish(): Promise<{ result?: Record<string, unknown>; error?: unknown }>;
 };
 

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -1,3 +1,4 @@
+import EventEmitter from "events";
 import { HandlesDef } from "../schema";
 import type { BlockJobStackLevel } from "./block";
 
@@ -126,7 +127,7 @@ export interface Context<
   readonly runBlock: (
     blockName: string,
     inputs: Record<string, any>
-  ) => Promise<void>;
+  ) => Promise<EventEmitter>;
 
   /**
    * reporter block finish. it can contain error or result.

--- a/packages/oocana/package.json
+++ b/packages/oocana/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@wopjs/disposable": "^0.1.11",
     "mqtt": "^5.7.0",
-    "remitter": "^0.4.6"
+    "remitter": "^0.5.0"
   },
   "devDependencies": {
     "@oomol/oocana-types": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@types/lodash.throttle':
         specifier: ^4.1.9
         version: 4.1.9
+      '@wopjs/event':
+        specifier: ^0.1.5
+        version: 0.1.5
       lodash.throttle:
         specifier: ^4.1.1
         version: 4.1.1
@@ -1099,6 +1102,9 @@ packages:
 
   '@wopjs/disposable@0.1.19':
     resolution: {integrity: sha512-0vFOH+ltWFrP9yF8I+8CWUJstl2/b0dPFsEAeTK4UGsSgXhsECT2uPszsUfJSZqwhS2YVaMuYhB3rB2pIsU3HA==}
+
+  '@wopjs/event@0.1.5':
+    resolution: {integrity: sha512-x5U0NQgTpZyTmyQ8AaI5I/xNSHYlMUE/0y0/34jpgKZY4gYgKybgFOGUrTvc7zDX1/0MhFxVjl/6wZNHEqIW9w==}
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -3783,6 +3789,8 @@ snapshots:
   '@wopjs/disposable@0.1.12': {}
 
   '@wopjs/disposable@0.1.19': {}
+
+  '@wopjs/event@0.1.5': {}
 
   '@xmldom/xmldom@0.8.10': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         version: link:../packages/oocana-types
     devDependencies:
       remitter:
-        specifier: ^0.4.6
-        version: 0.4.6
+        specifier: ^0.5.0
+        version: 0.5.0
       vitest:
         specifier: ^3.1.0
         version: 3.1.2(@types/node@22.10.5)
@@ -94,8 +94,8 @@ importers:
         specifier: ^1.2.7
         version: 1.2.8
       remitter:
-        specifier: ^0.4.6
-        version: 0.4.6
+        specifier: ^0.5.0
+        version: 0.5.0
       winston:
         specifier: ^3.13.1
         version: 3.17.0
@@ -119,8 +119,8 @@ importers:
         specifier: ^5.7.0
         version: 5.10.3
       remitter:
-        specifier: ^0.4.6
-        version: 0.4.6
+        specifier: ^0.5.0
+        version: 0.5.0
     optionalDependencies:
       '@oomol/oocana-cli-aarch64-apple-darwin':
         specifier: 0.28.25
@@ -161,8 +161,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       remitter:
-        specifier: ^0.4.6
-        version: 0.4.6
+        specifier: ^0.5.0
+        version: 0.5.0
 
   packages/oocana-types:
     devDependencies:
@@ -170,8 +170,8 @@ importers:
         specifier: ^11.1.6
         version: 11.1.6(rollup@4.30.0)(tslib@2.8.1)(typescript@5.7.2)
       remitter:
-        specifier: ^0.4.6
-        version: 0.4.6
+        specifier: ^0.5.0
+        version: 0.5.0
       rollup:
         specifier: ^4.17.2
         version: 4.30.0
@@ -1102,9 +1102,6 @@ packages:
 
   '@vitest/utils@3.1.2':
     resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
-
-  '@wopjs/disposable@0.1.12':
-    resolution: {integrity: sha512-WA4LKN+DInW65WVI9PuOyCadqzlssYFoM3Mds85ZHpLWM/tMD5/0wG4FlKiX6NqsmR9Dioq2YV01sncFNrdu8A==}
 
   '@wopjs/disposable@0.1.19':
     resolution: {integrity: sha512-0vFOH+ltWFrP9yF8I+8CWUJstl2/b0dPFsEAeTK4UGsSgXhsECT2uPszsUfJSZqwhS2YVaMuYhB3rB2pIsU3HA==}
@@ -2367,8 +2364,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  remitter@0.4.6:
-    resolution: {integrity: sha512-avh1nPKkv+wPS9eDjaFIOD5rSKT0W1rjK1tSoEfmX9oF+NjFC3k9Db4vow+pP4ZhY5N06sJ+CfsEZp3+Jcb6kg==}
+  remitter@0.5.0:
+    resolution: {integrity: sha512-nFsKy8xSysqazAZxAKon1pXu6rV3MRLWeYZWmq0sY3YtAlrjoR9ZpnTUyWzjgwTa4PyKtLxRBdCXUmsQ8eCW6g==}
 
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
@@ -3792,8 +3789,6 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@wopjs/disposable@0.1.12': {}
-
   '@wopjs/disposable@0.1.19': {}
 
   '@wopjs/event@0.1.5': {}
@@ -5185,9 +5180,9 @@ snapshots:
       - encoding
       - supports-color
 
-  remitter@0.4.6:
+  remitter@0.5.0:
     dependencies:
-      '@wopjs/disposable': 0.1.12
+      '@wopjs/disposable': 0.1.19
       adaptive-set: 0.1.3
 
   repeat-string@1.6.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,12 +160,18 @@ importers:
       lodash.throttle:
         specifier: ^4.1.1
         version: 4.1.1
+      remitter:
+        specifier: ^0.4.6
+        version: 0.4.6
 
   packages/oocana-types:
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
         version: 11.1.6(rollup@4.30.0)(tslib@2.8.1)(typescript@5.7.2)
+      remitter:
+        specifier: ^0.4.6
+        version: 0.4.6
       rollup:
         specifier: ^4.17.2
         version: 4.30.0


### PR DESCRIPTION
add `context.runBlock` API

```typescript
import type { Remitter } from "remitter";

export interface Context {
  readonly runBlock: (
    blockName: string,
    inputs: Record<string, any>
  ) => RunResponse;
}

export type RunResponse = {
  events: Remitter<BlockActionEvent>;
  onOutput(listener: (data: { handle: string; value: unknown }) => void): void;
  finish(): Promise<{ result?: Record<string, unknown>; error?: unknown }>;
};
```

---

Example

```typescript
...
  // Run the "counter" block with some input
  const res = context.runBlock("counter", { input: "test" });
  res.onOutput(data => {
    const { handle, value } = data;
    console.log(
      `Received output from counter block: handle=${handle}, output=${value}`
    );
  });
  const { result, error } = await res.finish();
  if (error) {
    console.error("Error in counter block:", error);
    throw new Error("Counter block failed with error: " + error);
  } else {
    console.log("Result from counter block:", result);
  }

...

```