### PR TITLE
feat: output api add options parameter

### DIFF
--- a/flow-examples/flows/special-output/flow.oo.yaml
+++ b/flow-examples/flows/special-output/flow.oo.yaml
@@ -1,0 +1,56 @@
+nodes:
+  - task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: a
+          value: input value
+      outputs_def:
+        - handle: out
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+typescript#2.ts
+    title: "TypeScript #2"
+    node_id: +typescript#2
+    inputs_from:
+      - handle: a
+        from_node:
+          - node_id: +typescript#1
+            output_handle: output
+  - node_id: +typescript#1
+    title: "TypeScript #1"
+    icon: ":skill-icons:typescript:"
+    task:
+      ui:
+        default_width: 450
+      inputs_def:
+        []
+      outputs_def:
+        - handle: output
+          json_schema:
+            {}
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+scriptlet#2.ts
+  - node_id: end
+    title: "TypeScript #3"
+    inputs_from:
+      - handle: a
+        from_node:
+          - node_id: +typescript#1
+            output_handle: output
+    task:
+      ui:
+        default_width: 450
+      inputs_def:
+        - handle: a
+          value: input value
+      outputs_def:
+        - handle: out
+      executor:
+        name: nodejs
+        options:
+          entry: scriptlets/+scriptlet#1.ts
+          spawn: false

--- a/flow-examples/flows/special-output/scriptlets/+scriptlet#1.ts
+++ b/flow-examples/flows/special-output/scriptlets/+scriptlet#1.ts
@@ -1,0 +1,16 @@
+import type { Context } from "@oomol/types/oocana";
+
+type Inputs = {
+  a: string;
+  b: string;
+};
+type Outputs = {
+  out: string;
+};
+
+export default async function (
+  _inputs: Inputs,
+  _context: Context<Inputs, Outputs>
+): Promise<Outputs> {
+  return { out: "out" };
+}

--- a/flow-examples/flows/special-output/scriptlets/+scriptlet#2.ts
+++ b/flow-examples/flows/special-output/scriptlets/+scriptlet#2.ts
@@ -1,0 +1,22 @@
+//#region generated meta
+type Inputs = {};
+type Outputs = {
+  output: any;
+};
+//#endregion
+
+import type { Context } from "@oomol/oocana-types";
+
+export default async function (
+  _params: Inputs,
+  context: Context<Inputs, Outputs>
+): Promise<Partial<Outputs> | undefined | void> {
+  context.output("output", "aaa", {
+    toNodeInputs: [
+      {
+        node_id: "end",
+        input_handle: "a",
+      },
+    ],
+  });
+}

--- a/flow-examples/flows/special-output/scriptlets/+scriptlet#2.ts
+++ b/flow-examples/flows/special-output/scriptlets/+scriptlet#2.ts
@@ -12,7 +12,7 @@ export default async function (
   context: Context<Inputs, Outputs>
 ): Promise<Partial<Outputs> | undefined | void> {
   context.output("output", "aaa", {
-    toNodeInputs: [
+    to_node: [
       {
         node_id: "end",
         input_handle: "a",

--- a/flow-examples/flows/special-output/scriptlets/+typescript#2.ts
+++ b/flow-examples/flows/special-output/scriptlets/+typescript#2.ts
@@ -1,0 +1,17 @@
+import type { Context } from "@oomol/types/oocana";
+import { error } from "console";
+
+type Inputs = {
+  a: string;
+  b: string;
+};
+type Outputs = {
+  out: string;
+};
+
+export default async function (
+  _inputs: Inputs,
+  _context: Context<Inputs, Outputs>
+): Promise<Outputs> {
+  throw new Error("this node should never be executed")
+}

--- a/flow-examples/test/flow.test.ts
+++ b/flow-examples/test/flow.test.ts
@@ -141,6 +141,13 @@ describe(
       expect(sessionFinished[0].data.partial).not.toBeUndefined();
     });
 
+    it("run special-output flow", async () => {
+      const { code, events } = await runFlow("special-output");
+      const latestFinished = events.findLast(e => e.event === "BlockFinished");
+      expect(latestFinished?.data.stacks?.[0].node_id).toBe("end");
+      expect(code).toBe(0);
+    });
+
     it("run query-block flow", async () => {
       const { code, events } = await runFlow("query-block");
       const latestFinished = events.findLast(e => e.event === "BlockFinished");

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -533,9 +533,9 @@ export class ContextImpl implements Context {
   output = async <THandle extends string>(
     handle: THandle,
     output: any,
-    option: {
-      toFlowOutputs?: { output_handle: string }[];
-      toNodeInputs?: { node_id: string; input_handle: string }[];
+    options: {
+      to_flow?: { output_handle: string }[];
+      to_node?: { node_id: string; input_handle: string }[];
     } = {}
   ) => {
     if (!(handle in this.outputsDef)) {
@@ -559,12 +559,12 @@ export class ContextImpl implements Context {
       job_id: this.jobId,
       handle,
       output: value,
-      option:
-        option.toFlowOutputs || option.toNodeInputs
+      options:
+        options.to_flow || options.to_node
           ? {
               target: {
-                toFlowOutputs: option.toFlowOutputs,
-                toNodeInputs: option.toNodeInputs,
+                to_flow: options.to_flow,
+                to_node: options.to_node,
               },
             }
           : undefined,

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -530,7 +530,14 @@ export class ContextImpl implements Context {
     });
   };
 
-  output = async <THandle extends string>(handle: THandle, output: any) => {
+  output = async <THandle extends string>(
+    handle: THandle,
+    output: any,
+    option: {
+      toFlowOutputs?: { output_handle: string }[];
+      toNodeInputs?: { node_id: string; input_handle: string }[];
+    } = {}
+  ) => {
     if (!(handle in this.outputsDef)) {
       await this.warning(
         `Output handle key: [${handle}] is not defined in Block outputs schema.`
@@ -552,6 +559,15 @@ export class ContextImpl implements Context {
       job_id: this.jobId,
       handle,
       output: value,
+      option:
+        option.toFlowOutputs || option.toNodeInputs
+          ? {
+              target: {
+                toFlowOutputs: option.toFlowOutputs,
+                toNodeInputs: option.toNodeInputs,
+              },
+            }
+          : undefined,
     });
 
     this.reportProgress.flush();

--- a/packages/oocana-types/src/block.ts
+++ b/packages/oocana-types/src/block.ts
@@ -56,6 +56,12 @@ export interface IMainframeBlockOutput<TOutput = any> extends JobInfo {
   type: "BlockOutput";
   handle: string;
   output: TOutput;
+  option?: {
+    target?: {
+      toFlowOutputs?: { output_handle: string }[];
+      toNodeInputs?: { node_id: string; input_handle: string }[];
+    };
+  };
 }
 
 export interface IMainframeBlockOutputs<TOutput = any> extends JobInfo {

--- a/packages/oocana-types/src/block.ts
+++ b/packages/oocana-types/src/block.ts
@@ -56,10 +56,10 @@ export interface IMainframeBlockOutput<TOutput = any> extends JobInfo {
   type: "BlockOutput";
   handle: string;
   output: TOutput;
-  option?: {
+  options?: {
     target?: {
-      toFlowOutputs?: { output_handle: string }[];
-      toNodeInputs?: { node_id: string; input_handle: string }[];
+      to_flow?: { output_handle: string }[];
+      to_node?: { node_id: string; input_handle: string }[];
     };
   };
 }

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -130,7 +130,17 @@ export interface Context<
      */
     <THandle extends Extract<keyof TOutputs, string>>(
       handle: THandle,
-      output: TOutputs[THandle]
+      output: TOutputs[THandle],
+      /** if toFlowOutputs or toNodeInputs is provided, the output will be sent to the specified handles. if none of these is provided, the output will be sent to the all. */
+      option?: {
+        toFlowOutputs?: {
+          output_handle: string;
+        }[];
+        toNodeInputs?: {
+          node_id: string;
+          input_handle: string;
+        }[];
+      }
     ): Promise<void>;
   };
 

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -132,11 +132,11 @@ export interface Context<
       handle: THandle,
       output: TOutputs[THandle],
       /** if toFlowOutputs or toNodeInputs is provided, the output will be sent to the specified handles. if none of these is provided, the output will be sent to the all. */
-      option?: {
-        toFlowOutputs?: {
+      options?: {
+        to_flow?: {
           output_handle: string;
         }[];
-        toNodeInputs?: {
+        to_node?: {
           node_id: string;
           input_handle: string;
         }[];


### PR DESCRIPTION
https://github.com/oomol/oocana-rust/pull/227 's nodejs implement and types


if toFlowOutputs or toNodeInputs is provided, the output will be sent to the specified handles. if none of these is provided, the output will be sent to the all

```typescript
// will send to all nodes and flow
context.output("key", "value", {});

// only output to end node_id
context.output("output", "aaa", {
  to_node: [
    {
      node_id: "end",
      input_handle: "a",
    },
  ],
});

// if add to_flow or to_node with empty list, output will not send to any nodes.
// output will not send to any node or flow.
context.output("output", "aa", {
  to_node: [],
}
```