### PR TITLE
feat: improve run block and query block

### DIFF
--- a/flow-examples/flows/query-block/scriptlets/+typescript#1.ts
+++ b/flow-examples/flows/query-block/scriptlets/+typescript#1.ts
@@ -20,7 +20,7 @@ export default async function (
     const res = await context.queryBlock("self::counter");
     console.log("Query result from 'self::counter':", res);
 
-    if (res.type !== "block") {
+    if (res.type !== "task") {
       throw new Error(
         "Expected 'self::counter' to be a block, but got: " + res.type
       );

--- a/flow-examples/flows/query-block/scriptlets/+typescript#1.ts
+++ b/flow-examples/flows/query-block/scriptlets/+typescript#1.ts
@@ -19,6 +19,12 @@ export default async function (
   try {
     const res = await context.queryBlock("self::counter");
     console.log("Query result from 'self::counter':", res);
+
+    if (res.type !== "block") {
+      throw new Error(
+        "Expected 'self::counter' to be a block, but got: " + res.type
+      );
+    }
   } catch (error) {
     throw new Error(
       "Error querying block 'self::counter': " +

--- a/flow-examples/test/flow.test.ts
+++ b/flow-examples/test/flow.test.ts
@@ -148,6 +148,12 @@ describe(
         e => e.event === "SubflowBlockProgress"
       );
 
+      expect(
+        subflowProgress.every(
+          e => e.data.progress >= 0 && e.data.progress <= 100
+        )
+      ).toBe(true);
+
       expect(subflowProgress.length).greaterThanOrEqual(
         8,
         `subflowProgress: ${JSON.stringify(subflowProgress)}`

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -213,7 +213,7 @@ export class ContextImpl implements Context {
   queryBlock = async (
     block_name: string
   ): Promise<{
-    type: "block" | "subflow";
+    type: "task" | "subflow";
     description?: string;
     inputs_def?: HandlesDef;
     outputs_def?: HandlesDef;

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -388,6 +388,10 @@ export class ContextImpl implements Context {
           send(onProgress, msg.rate);
           break;
         }
+        case "SubflowBlockProgress": {
+          send(onProgress, msg.progress);
+          break;
+        }
         case "BlockPreview": {
           send(onPreview, msg.payload);
           break;

--- a/packages/oocana-sdk/src/context.ts
+++ b/packages/oocana-sdk/src/context.ts
@@ -213,6 +213,7 @@ export class ContextImpl implements Context {
   queryBlock = async (
     block_name: string
   ): Promise<{
+    type: "block" | "subflow";
     description?: string;
     inputs_def?: HandlesDef;
     outputs_def?: HandlesDef;

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -272,7 +272,7 @@ export interface Context<
    * }
    */
   readonly queryBlock: (blockName: string) => Promise<{
-    type: "block" | "subflow";
+    type: "task" | "subflow";
     description?: string;
     inputs_def?: HandlesDef;
     outputs_def?: HandlesDef;

--- a/packages/oocana-types/src/external/context.ts
+++ b/packages/oocana-types/src/external/context.ts
@@ -272,6 +272,7 @@ export interface Context<
    * }
    */
   readonly queryBlock: (blockName: string) => Promise<{
+    type: "block" | "subflow";
     description?: string;
     inputs_def?: HandlesDef;
     outputs_def?: HandlesDef;

--- a/packages/oocana-types/src/external/reporter.ts
+++ b/packages/oocana-types/src/external/reporter.ts
@@ -62,7 +62,7 @@ export interface SubflowBlockStarted extends BlockInfo {
 export interface SubflowBlockProgress extends BlockInfo {
   readonly type: "SubflowBlockProgress";
   /** 0 ~ 100 */
-  readonly rate: number;
+  readonly progress: number;
 }
 
 export interface SubflowBlockFinished extends BlockInfo {


### PR DESCRIPTION
1. runBlock add subflow progress to onProgress
2. queryBlock response add `type` filed, which is `task` or `subflow`