### PR TITLE
feat(oocana): add connector base url api

### DIFF
--- a/packages/oocana/src/oocana.ts
+++ b/packages/oocana/src/oocana.ts
@@ -65,6 +65,8 @@ interface RunConfig {
   searchPaths?: string[];
   /** Remote block API base URL. Overrides OOCANA_REMOTE_BLOCK_URL env var. */
   remoteBlockUrl?: string;
+  /** Connector API base URL. Overrides OOCANA_CONNECTOR_BASE_URL env var. */
+  connectorBaseUrl?: string;
   /** Timeout in seconds for remote block execution. Overrides OOCANA_REMOTE_BLOCK_TIMEOUT env var. Default is 1800 (30 minutes). Use 0 to disable timeout and poll indefinitely. */
   remoteBlockTimeout?: number;
 }
@@ -133,6 +135,7 @@ function buildRunConfigArgs({
   envFile,
   searchPaths,
   remoteBlockUrl,
+  connectorBaseUrl,
   remoteBlockTimeout,
 }: RunConfig): string[] {
   const args: string[] = [];
@@ -191,6 +194,9 @@ function buildRunConfigArgs({
 
   if (remoteBlockUrl) {
     args.push("--remote-block-url", remoteBlockUrl);
+  }
+  if (connectorBaseUrl) {
+    args.push("--connector-base-url", connectorBaseUrl);
   }
   if (remoteBlockTimeout !== undefined) {
     args.push("--remote-block-timeout", String(remoteBlockTimeout));

--- a/packages/oocana/test/oocana.test.ts
+++ b/packages/oocana/test/oocana.test.ts
@@ -1,0 +1,131 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { spawnMock, reporterConnectMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  reporterConnectMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock("../src/reporter", () => ({
+  Reporter: {
+    connect: reporterConnectMock,
+  },
+}));
+
+import { Oocana } from "../src/oocana";
+
+interface MockChildProcess extends EventEmitter {
+  kill: ReturnType<typeof vi.fn>;
+  killed: boolean;
+  signalCode: NodeJS.Signals | null;
+  stdout: PassThrough;
+  stderr: PassThrough;
+}
+
+function createChildProcessMock(): MockChildProcess {
+  const process = new EventEmitter() as MockChildProcess;
+  process.stdout = new PassThrough();
+  process.stderr = new PassThrough();
+  process.killed = false;
+  process.signalCode = null;
+  process.kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
+    process.killed = true;
+    process.signalCode = signal;
+    process.emit("close", null, signal);
+  });
+  return process;
+}
+
+describe("Oocana", () => {
+  beforeEach(() => {
+    reporterConnectMock.mockResolvedValue({
+      onMessage: vi.fn(),
+      disconnect: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes connectorBaseUrl to runFlow cli args", async () => {
+    const childProcess = createChildProcessMock();
+    spawnMock.mockReturnValue(childProcess);
+
+    const oocana = new Oocana("/tmp/oocana");
+    await oocana.connect("127.0.0.1:47688");
+
+    const cli = await oocana.runFlow({
+      flowPath: "/tmp/test.oo.yaml",
+      projectData: "/tmp/project-data",
+      pkgDataRoot: "/tmp/pkg-data-root",
+      connectorBaseUrl: "https://connector.example",
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/tmp/oocana",
+      [
+        "run",
+        "/tmp/test.oo.yaml",
+        "--reporter",
+        "--broker",
+        "127.0.0.1:47688",
+        "--project-data",
+        "/tmp/project-data",
+        "--pkg-data-root",
+        "/tmp/pkg-data-root",
+        "--connector-base-url",
+        "https://connector.example",
+      ],
+      expect.objectContaining({
+        env: expect.any(Object),
+      })
+    );
+
+    childProcess.emit("close", 0, null);
+    await cli.wait();
+  });
+
+  it("passes connectorBaseUrl to runBlock cli args", async () => {
+    const childProcess = createChildProcessMock();
+    spawnMock.mockReturnValue(childProcess);
+
+    const oocana = new Oocana("/tmp/oocana");
+    await oocana.connect("127.0.0.1:47688");
+
+    const cli = await oocana.runBlock({
+      blockPath: "/tmp/block",
+      projectData: "/tmp/project-data",
+      pkgDataRoot: "/tmp/pkg-data-root",
+      connectorBaseUrl: "https://connector.example",
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/tmp/oocana",
+      [
+        "run",
+        "/tmp/block",
+        "--reporter",
+        "--broker",
+        "127.0.0.1:47688",
+        "--project-data",
+        "/tmp/project-data",
+        "--pkg-data-root",
+        "/tmp/pkg-data-root",
+        "--connector-base-url",
+        "https://connector.example",
+      ],
+      expect.objectContaining({
+        env: expect.any(Object),
+      })
+    );
+
+    childProcess.emit("close", 0, null);
+    await cli.wait();
+  });
+});


### PR DESCRIPTION
## Summary
- add `connectorBaseUrl` to the oocana node run config API
- pass `connectorBaseUrl` through to the oocana CLI as `--connector-base-url`
- add tests covering both runFlow and runBlock argument construction

## Verification
- `pnpm -F @oomol/oocana run ts-check`
- `pnpm -F @oomol/oocana exec vitest run test/oocana.test.ts`
- `pnpm -F @oomol/oocana run build`
- `pnpm -F @oomol/oocana run test` still fails on the pre-existing `SIGSEGV` timeout in `packages/oocana/test/cli.test.ts`