### PR TITLE
fix(executor): pin pnpm for packed installer

### DIFF
--- a/executor.sh
+++ b/executor.sh
@@ -13,7 +13,7 @@ corepack enable
 
 pnpm install && pnpm build
 tarball=$(cd packages/executor && pnpm pack --pack-destination /tmp/executor)
-tar -zxvf $tarball -C /tmp/executor
+tar -zxvf "$tarball" -C /tmp/executor
 (cd /tmp/executor/package && npm pkg delete devDependencies && npm pkg set "packageManager=$package_manager" && pnpm install)
 (cd /tmp/executor/package/dist && chmod +x nodejs-executor)
 

--- a/executor.sh
+++ b/executor.sh
@@ -6,6 +6,7 @@ echo $DIR
 cd $DIR
 
 mp=m
+package_manager=$(node -p "require('./package.json').packageManager")
 
 sudo ovmlayer create executor
 corepack enable
@@ -13,7 +14,7 @@ corepack enable
 pnpm install && pnpm build
 tarball=$(cd packages/executor && pnpm pack --pack-destination /tmp/executor)
 tar -zxvf $tarball -C /tmp/executor
-(cd /tmp/executor/package && npm pkg delete devDependencies && pnpm install)
+(cd /tmp/executor/package && npm pkg delete devDependencies && npm pkg set "packageManager=$package_manager" && pnpm install)
 (cd /tmp/executor/package/dist && chmod +x nodejs-executor)
 
 mv /tmp/executor/package /tmp/executor/executor

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -32,5 +32,6 @@
     "@hyrious/esbuild-dev": "^0.10.10",
     "minimist": "^1.2.7",
     "remitter": "^0.5.1"
-  }
+  },
+  "packageManager": "pnpm@9.12.3"
 }


### PR DESCRIPTION
## Summary
- add the executor package manager pin so the published package records the intended pnpm version
- inject the root packageManager into the unpacked executor tarball before the production install
- prevents Corepack from resolving the packed install to pnpm 11 and failing on ignored dependency builds

## Verification
- bash -n executor.sh
- pnpm -F @oomol/node-executor run build
- verified an unpacked executor package with packageManager set resolves pnpm -v to 9.12.3