### PR TITLE
ci: switch create-github-app-token to client-id

### DIFF
--- a/.github/workflows/layer.yml
+++ b/.github/workflows/layer.yml
@@ -48,9 +48,9 @@ jobs:
           fi
       - name: Generate GitHub App Token for oomol/${{ env.OVMLAYER_REPOSITORY }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OOMOL_DOWNLOADER_APP_ID }}
+          client-id: ${{ vars.OOMOL_DOWNLOADER_APP_CLIENT_ID }}
           private-key: ${{ secrets.OOMOL_DOWNLOADER_APP_PRIVATE_KEY }}
           owner: oomol
           repositories: ${{ env.OVMLAYER_REPOSITORY }}

--- a/.github/workflows/oocana-node.yml
+++ b/.github/workflows/oocana-node.yml
@@ -26,9 +26,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Generate GitHub App Token for oomol/${{ env.OVMLAYER_REPOSITORY }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OOMOL_DOWNLOADER_APP_ID }}
+          client-id: ${{ vars.OOMOL_DOWNLOADER_APP_CLIENT_ID }}
           private-key: ${{ secrets.OOMOL_DOWNLOADER_APP_PRIVATE_KEY }}
           owner: oomol
           repositories: ${{ env.OVMLAYER_REPOSITORY }}


### PR DESCRIPTION
`actions/create-github-app-token` 自 v3.1.0 起弃用 `app-id` 输入并改用 `client-id`，每次运行都会打印 "Input 'app-id' has been deprecated" 告警。本 PR 改为传组织级变量 `OOMOL_DOWNLOADER_APP_CLIENT_ID`（已配置，所有仓库可见），并把 `@v2` 升到 `@v3`，因为 `client-id` 输入只在 v3.1.0 之后存在。v3 的破坏性变更只有 node24 运行时（自托管 runner 需 v2.327.1 以上，GitHub 托管与 Blacksmith runner 均已满足）和需显式开启代理，这里都不受影响。
